### PR TITLE
Add start and select button support

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -73,8 +73,6 @@ BleGamepad::BleGamepad(std::string deviceName, std::string deviceManufacturer, u
 
 void BleGamepad::resetButtons() {
   memset(&_buttons,0,sizeof(_buttons));
-  _start = false;
-  _select = false;
 }
 
 void BleGamepad::setControllerType(uint8_t controllerType){
@@ -106,7 +104,7 @@ void BleGamepad::begin(uint16_t buttonCount, uint8_t hatSwitchCount, bool includ
 	_includeSteering = includeSteering;
 
 	if (_includeStart) { _buttonCount++; }
-	if (_includeStart) { _buttonCount++; }
+	if (_includeSelect) { _buttonCount++; }
 
 	uint8_t axisCount = 0;
 	if (_includeXAxis){ axisCount++; }
@@ -155,45 +153,48 @@ void BleGamepad::begin(uint16_t buttonCount, uint8_t hatSwitchCount, bool includ
 	
 	if (_buttonCount > 0) {
 
-		// USAGE_PAGE (Button)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x05;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
+		if (_buttonCount - (int)_includeStart - (int)_includeSelect > 0){
 
-		// USAGE_MINIMUM (Button 1)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x19;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
+			// USAGE_PAGE (Button)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x05;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
 
-		// USAGE_MAXIMUM (Up to 128 buttons possible)            
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x29;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = _buttonCount - (int)_includeStart - (int)_includeSelect;
+			// LOGICAL_MINIMUM (0)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x15;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
 
-		// LOGICAL_MINIMUM (0)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x15;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
+			// LOGICAL_MAXIMUM (1)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x25;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
 
-		// LOGICAL_MAXIMUM (1)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x25;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
+			// REPORT_SIZE (1)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x75;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
 
-		// REPORT_SIZE (1)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x75;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
+			// USAGE_MINIMUM (Button 1)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x19;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
 
-		// REPORT_COUNT (# of buttons)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x95;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = _buttonCount - (int)_includeStart - (int)_includeSelect;
+			// USAGE_MAXIMUM (Up to 128 buttons possible)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x29;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = _buttonCount - (int)_includeStart - (int)_includeSelect;
 
-		// UNIT_EXPONENT (0)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x55;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
+			// REPORT_COUNT (# of buttons)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x95;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = _buttonCount - (int)_includeStart - (int)_includeSelect;
 
-		// UNIT (None)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x65;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
+			// UNIT_EXPONENT (0)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x55;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
 
-		// INPUT (Data,Var,Abs)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
+			// UNIT (None)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x65;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
+
+			// INPUT (Data,Var,Abs)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
+		}
 
 		if (_includeStart || _includeSelect){
 
@@ -201,19 +202,37 @@ void BleGamepad::begin(uint16_t buttonCount, uint8_t hatSwitchCount, bool includ
 			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x05;
 			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
 
-			// REPORT_COUNT
+			// LOGICAL_MINIMUM (0)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x15;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
+
+			// LOGICAL_MAXIMUM (1)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x25;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
+
+			// REPORT_SIZE (1)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x75;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
+
+			// REPORT_COUNT (Up to 2)
 			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x95;
 			tempHidReportDescriptor[hidReportDescriptorSize++] = (int)_includeStart + (int)_includeSelect;
 
 			if (_includeStart){
+				// USAGE (Start)
 				tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
 				tempHidReportDescriptor[hidReportDescriptorSize++] = 0x3D;
 			}
 
 			if (_includeSelect){
+				// USAGE (Select)
 				tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
 				tempHidReportDescriptor[hidReportDescriptorSize++] = 0x3E;
 			}
+
+			// INPUT (Data,Var,Abs)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
 
 		}
 

--- a/BleGamepad.h
+++ b/BleGamepad.h
@@ -182,7 +182,7 @@
 class BleGamepad {
 private:
   uint8_t  _controllerType;
-  uint8_t _buttons[16];	//8 bytes x 16 --> 128 bytes 
+  uint8_t _buttons[16];	//8 bits x 16 --> 128 bits (includes start and select)
   int16_t _x;
   int16_t _y;
   int16_t _z;
@@ -201,8 +201,10 @@ private:
   int16_t _hat3;
   int16_t _hat4;
   bool _autoReport;
-  uint16_t _buttonCount;
+  uint16_t _buttonCount; // (includes  start and select)
   uint8_t _hatSwitchCount;
+  bool _includeStart;
+  bool _includeSelect;
   bool _includeXAxis;
   bool _includeYAxis;
   bool _includeZAxis;
@@ -233,6 +235,10 @@ public:
   void setAxes(int16_t x = 0, int16_t y = 0, int16_t z = 0, int16_t rZ = 0, int16_t rX = 0, int16_t rY = 0, int16_t slider1 = 0, int16_t slider2 = 0, signed char hat1 = 0, signed char hat2 = 0, signed char hat3 = 0, signed char hat4 = 0);
   void press(uint8_t b = BUTTON_1);   // press BUTTON_1 by default
   void release(uint8_t b = BUTTON_1); // release BUTTON_1 by default
+  void pressStart();
+  void pressSelect();
+  void releaseStart();
+  void releaseSelect();
   void setLeftThumb(int16_t x = 0, int16_t y = 0);
   void setRightThumb(int16_t z = 0, int16_t rZ = 0);
   void setLeftTrigger(int16_t rX = 0);

--- a/BleGamepad.h
+++ b/BleGamepad.h
@@ -229,7 +229,7 @@ private:
 
 public:
   BleGamepad(std::string deviceName = "ESP32 BLE Gamepad", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
-  void begin(uint16_t buttonCount = 16, uint8_t hatSwitchCount = 1, bool includeXAxis = true, bool includeYAxis = true, bool includeZAxis = true, bool includeRzAxis = true, bool includeRxAxis = true, bool includeRyAxis = true, bool includeSlider1 = true, bool includeSlider2 = true, bool includeRudder = false, bool includeThrottle = false, bool includeAccelerator = false, bool includeBrake = false, bool includeSteering = false);
+  void begin(uint16_t buttonCount = 16, uint8_t hatSwitchCount = 1, bool includeStart = false, bool includeSelect = false, bool includeXAxis = true, bool includeYAxis = true, bool includeZAxis = true, bool includeRzAxis = true, bool includeRxAxis = true, bool includeRyAxis = true, bool includeSlider1 = true, bool includeSlider2 = true, bool includeRudder = false, bool includeThrottle = false, bool includeAccelerator = false, bool includeBrake = false, bool includeSteering = false);
   void end(void);
   void setControllerType(uint8_t controllerType = CONTROLLER_TYPE_GAMEPAD);
   void setAxes(int16_t x = 0, int16_t y = 0, int16_t z = 0, int16_t rZ = 0, int16_t rX = 0, int16_t rY = 0, int16_t slider1 = 0, int16_t slider2 = 0, signed char hat1 = 0, signed char hat2 = 0, signed char hat3 = 0, signed char hat4 = 0);


### PR DESCRIPTION
I added support for the start and select button from the Generic Desktop hid usage page. Since these buttons only take up one single bit, I stored their value in the byte array that the other buttons are also stored in. This means that they can benefit from the same bit padding at the end of that part of the report, but also means that the code that builds the hid report descriptor has to be a little more complicated/janky. The _buttonCount variable also includes the start and select button, so to get the count of all buttons that are not start or select buttons, we can subtract the booleans that tell whether there are start and select buttons, as these evaluate to 0 or 1.

I might create another pull request in the future adding support for a few more special buttons (volume control, home, etc.), in which case i will create a separate array for these, with their own bit padding and button count and their own, more proper, spot in the hid report descriptor code, but right now that seems excessive for just two buttons.

Also, this is my first ever contribution to open source code :). 