### PR TITLE
notify battery level change only if connected

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -1293,7 +1293,9 @@ void BleGamepad::setBatteryLevel(uint8_t level)
     this->batteryLevel = level;
     if (hid != 0){
         this->hid->setBatteryLevel(this->batteryLevel);
-	this->hid->batteryLevel()->notify();
+	if (this->isConnected()){
+	    this->hid->batteryLevel()->notify();
+	}
     }
 }
 


### PR DESCRIPTION
Add `isConnected()` test for `notify()` call.
`this->hid->setBatteryLevel()` call is left outside the test as the function is used in `begin()` to set initial level value.
