### PR TITLE
Add support for custom guid version.

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -34,6 +34,7 @@ uint8_t reportSize = 0;
 uint8_t numOfButtonBytes = 0;
 uint16_t vid;
 uint16_t pid;
+uint16_t guidVersion;
 uint16_t axesMin;
 uint16_t axesMax;
 uint16_t simulationMin;
@@ -89,6 +90,7 @@ void BleGamepad::begin(BleGamepadConfiguration *config)
 
 	vid = configuration.getVid();
 	pid = configuration.getPid();
+	guidVersion = configuration.getGuidVersion();
 
 	uint8_t high = highByte(vid);
 	uint8_t low = lowByte(vid);
@@ -99,6 +101,10 @@ void BleGamepad::begin(BleGamepadConfiguration *config)
 	low = lowByte(pid);
 
 	pid = low << 8 | high;
+	
+	high = highByte(guidVersion);
+	low = lowByte(guidVersion);
+	guidVersion = low << 8 | high;
 
     uint8_t buttonPaddingBits = 8 - (configuration.getButtonCount() % 8);
     if (buttonPaddingBits == 8)
@@ -1400,7 +1406,7 @@ void BleGamepad::taskServer(void *pvParameter)
     );
     pCharacteristic_Hardware_Revision->setValue(hardwareRevision);
 
-    BleGamepadInstance->hid->pnp(0x01, vid, pid, 0x0110);
+    BleGamepadInstance->hid->pnp(0x01, vid, pid, guidVersion);
     BleGamepadInstance->hid->hidInfo(0x00, 0x01);
 
     NimBLEDevice::setSecurityAuth(BLE_SM_PAIR_AUTHREQ_BOND);

--- a/BleGamepadConfiguration.cpp
+++ b/BleGamepadConfiguration.cpp
@@ -10,6 +10,7 @@ BleGamepadConfiguration::BleGamepadConfiguration() : _controllerType(CONTROLLER_
                                                      _whichSimulationControls{false, false, false, false, false},
                                                      _vid(0xe502),
                                                      _pid(0xbbab),
+													 _guidVersion(0x0110),
                                                      _axesMin(0x0000),
                                                      _axesMax(0x7FFF),
                                                      _simulationMin(0x0000),
@@ -79,6 +80,7 @@ uint8_t BleGamepadConfiguration::getSimulationCount()
 
 uint16_t BleGamepadConfiguration::getVid(){ return _vid; }
 uint16_t BleGamepadConfiguration::getPid(){ return _pid; }
+uint16_t BleGamepadConfiguration::getGuidVersion(){ return _guidVersion; }
 int16_t BleGamepadConfiguration::getAxesMin(){ return _axesMin; }
 int16_t BleGamepadConfiguration::getAxesMax(){ return _axesMax; }
 int16_t BleGamepadConfiguration::getSimulationMin(){ return _simulationMin; }
@@ -179,6 +181,7 @@ void BleGamepadConfiguration::setIncludeBrake(bool value) { _whichSimulationCont
 void BleGamepadConfiguration::setIncludeSteering(bool value) { _whichSimulationControls[STEERING] = value; }
 void BleGamepadConfiguration::setVid(uint16_t value) { _vid = value; }
 void BleGamepadConfiguration::setPid(uint16_t value) { _pid = value; }
+void BleGamepadConfiguration::setGuidVersion(uint16_t value) { _guidVersion = value; }
 void BleGamepadConfiguration::setAxesMin(int16_t value) { _axesMin = value; }
 void BleGamepadConfiguration::setAxesMax(int16_t value) { _axesMax = value; }
 void BleGamepadConfiguration::setSimulationMin(int16_t value) { _simulationMin = value; }

--- a/BleGamepadConfiguration.h
+++ b/BleGamepadConfiguration.h
@@ -212,6 +212,7 @@ private:
     bool _whichSimulationControls[POSSIBLESIMULATIONCONTROLS];
     uint16_t _vid;
     uint16_t _pid;
+	uint16_t _guidVersion;
     int16_t _axesMin;
     int16_t _axesMax;
     int16_t _simulationMin;
@@ -261,6 +262,7 @@ public:
     const bool *getWhichSimulationControls() const;
     uint16_t getVid();
     uint16_t getPid();
+	uint16_t getGuidVersion();
     int16_t getAxesMin();
     int16_t getAxesMax();
     int16_t getSimulationMin();
@@ -302,6 +304,7 @@ public:
     void setWhichSimulationControls(bool rudder, bool throttle, bool accelerator, bool brake, bool steering);
     void setVid(uint16_t value);
     void setPid(uint16_t value);
+	void setGuidVersion(uint16_t value);
     void setAxesMin(int16_t value);
     void setAxesMax(int16_t value);
     void setSimulationMin(int16_t value);

--- a/keywords.txt
+++ b/keywords.txt
@@ -130,6 +130,7 @@ getIncludeSteering KEYWORD2
 getWhichSimulationControls KEYWORD2
 getVid KEYWORD2
 getPid KEYWORD2
+getGuidVersion KEYWORD2
 getAxesMin KEYWORD2
 getAxesMax KEYWORD2
 getSimulationMin KEYWORD2
@@ -141,6 +142,7 @@ getFirmwareRevision KEYWORD2
 getHardwareRevision KEYWORD2
 setVid KEYWORD2
 setPid KEYWORD2
+setGuidVersion KEYWORD2
 setAxesMin KEYWORD2
 setAxesMax KEYWORD2
 setSimulationMin KEYWORD2


### PR DESCRIPTION
While trying to create a cross platform controller for Godot/SDL2 I discovered that I had to change the GUID version in the Plug-n-Play characteristic. Now I'm able to emulate a virtual steam controller on Windows and Linux with:
```
bleGamepadConfig.setVid(0x28de); 
bleGamepadConfig.setPid(0x11ff);
bleGamepadConfig.setGuidVersion(0x0001);
```
which is recognized in Godot.

Godot and SDL2 have [a list](https://github.com/godotengine/godot/blob/master/core/input/gamecontrollerdb.txt) based on the os provided guid to load controller mappings. For windows only the vid and pid seem to matter, for linux vid, pid and version are combined into the guid, therefore the [hardcoded version 0x0110](https://github.com/lemmingDev/ESP32-BLE-Gamepad/blob/af97682c4e6da31bf5abd8ab4311636714fe6fc2/BleGamepad.cpp#L1403) breaks linux support for SDL2.

What do you think of letting the user access and edit this version?