### PR TITLE
Include stdexcept

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -11,6 +11,8 @@
 #include "BleGamepad.h"
 #include "BleGamepadConfiguration.h"
 
+#include <stdexcept>
+
 #if defined(CONFIG_ARDUHAL_ESP_LOG)
 #include "esp32-hal-log.h"
 #define LOG_TAG "BLEGamepad"


### PR DESCRIPTION
Fix the  error: 'invalid_argument' is not a member of 'std'