### PR TITLE
Fixing broken PID/VID

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -90,11 +90,11 @@ void BleGamepad::begin(BleGamepadConfiguration *config)
     firmwareRevision = configuration.getFirmwareRevision();
     hardwareRevision = configuration.getHardwareRevision();
 
-#ifndef PNPVersionField
 	vid = configuration.getVid();
 	pid = configuration.getPid();
 	guidVersion = configuration.getGuidVersion();
 
+#ifndef PNPVersionField
 	uint8_t high = highByte(vid);
 	uint8_t low = lowByte(vid);
 

--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -90,6 +90,7 @@ void BleGamepad::begin(BleGamepadConfiguration *config)
     firmwareRevision = configuration.getFirmwareRevision();
     hardwareRevision = configuration.getHardwareRevision();
 
+#ifndef PNPVersionField
 	vid = configuration.getVid();
 	pid = configuration.getPid();
 	guidVersion = configuration.getGuidVersion();
@@ -107,6 +108,7 @@ void BleGamepad::begin(BleGamepadConfiguration *config)
 	high = highByte(guidVersion);
 	low = lowByte(guidVersion);
 	guidVersion = low << 8 | high;
+#endif
 
     uint8_t buttonPaddingBits = 8 - (configuration.getButtonCount() % 8);
     if (buttonPaddingBits == 8)


### PR DESCRIPTION
Upstream NimBLE version 1.4.2 allows us to set the PID, VID and GUID normally without needing to flip high/low bytes. Using PNPVersionField to preserve backwards compatibility since it was added in the same upstream commit. If there's a better way to detect the upstream NimBLE version then that would probably be a better solution.