### PR TITLE
Fix compatibility with NimBle version 2.0.0

### DIFF
--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -4,13 +4,13 @@ BleConnectionStatus::BleConnectionStatus(void)
 {
 }
 
-void BleConnectionStatus::onConnect(NimBLEServer *pServer, ble_gap_conn_desc* desc)
+void BleConnectionStatus::onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo)
 {
-    pServer->updateConnParams(desc->conn_handle, 6, 7, 0, 600);
+    pServer->updateConnParams(connInfo.getConnHandle(), 6, 7, 0, 600);
     this->connected = true;
 }
 
-void BleConnectionStatus::onDisconnect(NimBLEServer *pServer)
+void BleConnectionStatus::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason)
 {
     this->connected = false;
 }

--- a/BleConnectionStatus.h
+++ b/BleConnectionStatus.h
@@ -14,8 +14,8 @@ class BleConnectionStatus : public NimBLEServerCallbacks
 public:
     BleConnectionStatus(void);
     bool connected = false;
-    void onConnect(NimBLEServer *pServer, ble_gap_conn_desc* desc);
-    void onDisconnect(NimBLEServer *pServer);
+    void onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo) override;
+    void onDisconnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo, int reason) override;
     NimBLECharacteristic *inputGamepad;
 };
 

--- a/BleOutputReceiver.cpp
+++ b/BleOutputReceiver.cpp
@@ -15,7 +15,7 @@ BleOutputReceiver::~BleOutputReceiver()
     }
 }
 
-void BleOutputReceiver::onWrite(NimBLECharacteristic *pCharacteristic)
+void BleOutputReceiver::onWrite(NimBLECharacteristic *pCharacteristic, NimBLEConnInfo& connInfo)
 {
     // Retrieve data sent from the host
     std::string value = pCharacteristic->getValue();

--- a/BleOutputReceiver.h
+++ b/BleOutputReceiver.h
@@ -14,7 +14,7 @@ class BleOutputReceiver : public NimBLECharacteristicCallbacks
 public:
     BleOutputReceiver(uint16_t outputReportLength);
     ~BleOutputReceiver();
-    void onWrite(NimBLECharacteristic *pCharacteristic) override;
+    void onWrite(NimBLECharacteristic *pCharacteristic, NimBLEConnInfo& connInfo) override;
     bool outputFlag = false;
     uint16_t outputReportLength;
     uint8_t *outputBuffer;


### PR DESCRIPTION
The 2.0.0 version of NimBLE has modified some method signatures, we need to update these signatures in order for callbacks to work properly.