### PR TITLE
Fixed advertising name not being set, leading to some devices not showing the Gamepad in their Bluetooth Managers.

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -1497,6 +1497,7 @@ void BleGamepad::taskServer(void *pvParameter)
 
     NimBLEAdvertising *pAdvertising = pServer->getAdvertising();
     pAdvertising->setAppearance(HID_GAMEPAD);
+    pAdvertising->setName(BleGamepadInstance->deviceName);
     pAdvertising->addServiceUUID(BleGamepadInstance->hid->getHidService()->getUUID());
     pAdvertising->start();
     BleGamepadInstance->hid->setBatteryLevel(BleGamepadInstance->batteryLevel);


### PR DESCRIPTION
The ESP32 was not showing in Android/iOS Bluetooth managers.
With the app called LightBlue, I noticed that the advertised device name was not set, "Unnamed", and for this reason hidden from the OS Bluetooth selection screen.
This fix uses the 'deviceName' set with BleGamepadConfig.