### PR TITLE
Fix Windows notifications not being sent on reconnection.

### DIFF
--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -7,10 +7,14 @@ BleConnectionStatus::BleConnectionStatus(void)
 void BleConnectionStatus::onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo)
 {
     pServer->updateConnParams(connInfo.getConnHandle(), 6, 7, 0, 600);
-    this->connected = true;
 }
 
 void BleConnectionStatus::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason)
 {
     this->connected = false;
+}
+
+void BleConnectionStatus::onAuthenticationComplete(NimBLEConnInfo& connInfo)
+{
+    this->connected = true;
 }

--- a/BleConnectionStatus.h
+++ b/BleConnectionStatus.h
@@ -17,6 +17,7 @@ public:
     bool connected = false;
     void onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo) override;
     void onDisconnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo, int reason) override;
+    void onAuthenticationComplete(NimBLEConnInfo& connInfo) override;
     NimBLECharacteristic *inputGamepad;
 };
 


### PR DESCRIPTION
When Windows bonds with a device and subscribes to notifications/indications of the device characteristics it does not re-subscribe on subsequent connections. If a notification is sent when Windows reconnects it will overwrite the stored subscription value in the NimBLE stack configuration with an invalid value which results in notifications/indications not being sent.

This change will ensure that no notification or indication is sent before authentication upon reconnection, avoiding the described issue described above.

Fixes #251 