### PR TITLE
Update BleGamepad.cpp

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -4,9 +4,7 @@
 #include "NimBLEHIDDevice.h"
 #include "HIDTypes.h"
 #include "HIDKeyboardTypes.h"
-#include <driver/adc.h>
 #include "sdkconfig.h"
-
 #include "BleConnectionStatus.h"
 #include "BleGamepad.h"
 #include "BleGamepadConfiguration.h"


### PR DESCRIPTION
Removed because its a deprecated legacy adc driver which gives a warning in arduino ide when compiling and not being used by BLE Gamepad library.