### PR TITLE
Add debug HID Report Descriptor as a build env 'BLE_GAMEPAD_DEBUG'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,11 @@ name: Compile Sketches
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  # https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') || github.ref != 'refs/heads/master' }}
+
 permissions: {}
 
 jobs:
@@ -19,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # See: https://github.com/arduino/compile-sketches#readme
       - name: Compile sketches

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -1,0 +1,47 @@
+---
+name: ESP32-BLE-Gamepad platformio CI
+
+'on':
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]*"
+    branches:
+      - "master"
+      - "ci-builds-*"
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') || github.ref != 'refs/heads/master' }}
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        board: [esp32dev, lolin_c3_mini]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+
+      - name: Build Test firmware for ${{ matrix.board }}
+        run: |
+          # pio run -d examples/TestAll/TestAll.ino -e ${{ matrix.board }} -D BLE_GAMEPAD_DEBUG=1 --verbose
+          cd test/ci_build
+          pio run -e ${{ matrix.board }} --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+
+# ========================
+# PlatformIO / Arduino
+# ========================
+
+# Build output
+.pio/
+*.pio
+*.elf
+*.bin
+*.hex
+*.map
+*.d
+*.cpp.o
+*.d.o
+
+# Library dependencies (built by PIO)
+.libdeps/
+
+# VSCode / IDE files
+.vscode/
+.idea/
+*.code-workspace
+
+# Mac / Linux / Windows system files
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.swp
+*~

--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -40,6 +40,10 @@ static const char *LOG_TAG = "BLEGamepad";
 #define POWER_STATE_CHARGING        3 // 0b11
 #define POWER_STATE_CRITICAL        3 // 0b11
 
+#ifdef BLE_GAMEPAD_DEBUG
+static void dumpHIDReport(const uint8_t* report, size_t len);
+#endif
+
 BleGamepad::BleGamepad(std::string deviceName, std::string deviceManufacturer, uint8_t batteryLevel, bool delayAdvertising) : _buttons(),
   _specialButtons(0),
   _x(0),
@@ -1038,7 +1042,7 @@ void BleGamepad::sendReport(void)
       }
     }
   
-    #ifdef BLEGAMEPAD_DEBUG
+    #ifdef BLE_GAMEPAD_DEBUG
       dumpHIDReport(m, sizeof(m));
     #endif
 
@@ -1965,19 +1969,22 @@ static void dumpHidReportDescriptor(const uint8_t* desc, size_t size) {
     Serial.println("\n\nCopy and paste the output above and use a parser such as at https://eleccelerator.com/usbdescreqparser to create a readable HID Report Descriptor\n\n");
 }
 
-static void dumpHIDReport(const uint8_t* report, size_t len)
+static void dumpHIDReport(const uint8_t* report, size_t size)
 {
-    if (!Serial) return;   // Serial not initialized
+    if (!Serial) {
+        // Serial not initialized yet, avoid printing
+        return;
+    }
 
-    Serial.println("=== HID Report Dump ===");
-    for (size_t i = 0; i < len; i++)
+    Serial.printf("[BLEGamepad][INFO] HID Report Dump size: %u bytes\n", (unsigned)size);
+    for (size_t i = 0; i < size; i++)
     {
         Serial.printf("%02X ", report[i]);
         // Optional: break line every 16 bytes
         if ((i + 1) % 16 == 0) Serial.println();
     }
     Serial.println();
-    Serial.println("======================");
+    Serial.println("\n[BLEGamepad][INFO] End of HID Report Dump");
 }
 #endif
 

--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -1937,6 +1937,30 @@ void BleGamepad::setPowerLevel(uint8_t powerLevel)
   setPowerStateAll(_batteryPowerInformation, _dischargingState, _chargingState, _powerLevel);
 }
 
+#if BLE_GAMEPAD_DEBUG
+static void dumpHidReportDescriptor(const uint8_t* desc, size_t size) {
+    if (!Serial) {
+        // Serial not initialized yet, avoid printing
+        return;
+    }
+
+    if (desc == nullptr || size == 0) {
+        Serial.println("[BLEGamepad][ERROR] HID Report Descriptor is null or empty!");
+        return;
+    }
+
+    Serial.printf("[BLEGamepad][INFO] HID Report Descriptor size: %u bytes\n", (unsigned)size);
+
+    for (size_t i = 0; i < size; i++) {
+        if (i % 16 == 0) {
+            Serial.printf("\n%03u: ", (unsigned)i);
+        }
+        Serial.printf("%02X ", desc[i]);
+    }
+    Serial.println("\n[BLEGamepad][INFO] End of HID Report Descriptor");
+}
+#endif
+
 void BleGamepad::beginNUS() 
 {
     if (!this->nusInitialized) 
@@ -2055,6 +2079,11 @@ void BleGamepad::taskServer(void *pvParameter)
   //    Serial.println();
   //}
   //Serial.println("------- HID DESCRIPTOR END -------");
+
+  // Print HidReportDescriptor to Serial
+  #if BLE_GAMEPAD_DEBUG
+    dumpHidReportDescriptor( BleGamepadInstance->tempHidReportDescriptor, BleGamepadInstance->hidReportDescriptorSize);
+  #endif
   
   BleGamepadInstance->hid->setReportMap((uint8_t *)customHidReportDescriptor, BleGamepadInstance->hidReportDescriptorSize);
   BleGamepadInstance->hid->startServices();

--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -40,7 +40,7 @@ static const char *LOG_TAG = "BLEGamepad";
 #define POWER_STATE_CHARGING        3 // 0b11
 #define POWER_STATE_CRITICAL        3 // 0b11
 
-#ifdef BLE_GAMEPAD_DEBUG
+#if BLE_GAMEPAD_DEBUG == 1
 static void dumpHIDReport(const uint8_t* report, size_t len);
 #endif
 
@@ -1042,7 +1042,7 @@ void BleGamepad::sendReport(void)
       }
     }
   
-    #ifdef BLE_GAMEPAD_DEBUG
+    #if BLE_GAMEPAD_DEBUG == 1
       dumpHIDReport(m, sizeof(m));
     #endif
 
@@ -1937,7 +1937,7 @@ void BleGamepad::setPowerLevel(uint8_t powerLevel)
   setPowerStateAll(_batteryPowerInformation, _dischargingState, _chargingState, _powerLevel);
 }
 
-#if BLE_GAMEPAD_DEBUG
+#if BLE_GAMEPAD_DEBUG == 1
 static void dumpHidReportDescriptor(const uint8_t* desc, size_t size) {
     if (!Serial) {
         // Serial not initialized yet, avoid printing
@@ -2098,9 +2098,8 @@ void BleGamepad::taskServer(void *pvParameter)
   uint8_t *customHidReportDescriptor = new uint8_t[BleGamepadInstance->hidReportDescriptorSize];
   memcpy(customHidReportDescriptor, BleGamepadInstance->tempHidReportDescriptor, BleGamepadInstance->hidReportDescriptorSize);
 
-
-  // Print HidReportDescriptor to Serial
-  #if BLE_GAMEPAD_DEBUG
+  #if BLE_GAMEPAD_DEBUG == 1
+    // Print HidReportDescriptor to Serial
     dumpHidReportDescriptor( BleGamepadInstance->tempHidReportDescriptor, BleGamepadInstance->hidReportDescriptorSize);
   #endif
   

--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -1038,16 +1038,12 @@ void BleGamepad::sendReport(void)
       }
     }
   
+    #ifdef BLEGAMEPAD_DEBUG
+      dumpHIDReport(m, sizeof(m));
+    #endif
+
     this->inputGamepad->setValue(m, sizeof(m));
     this->inputGamepad->notify();
-    
-    // Testing
-    //Serial.println("HID Report");
-    //for (int i = 0; i < sizeof(m); i++)
-    //{
-    //    Serial.printf("%02x", m[i]);
-    //    Serial.println();
-    //}
   }
 }
 
@@ -1968,6 +1964,21 @@ static void dumpHidReportDescriptor(const uint8_t* desc, size_t size) {
     Serial.println("\nCopy end above here ");
     Serial.println("\n\nCopy and paste the output above and use a parser such as at https://eleccelerator.com/usbdescreqparser to create a readable HID Report Descriptor\n\n");
 }
+
+static void dumpHIDReport(const uint8_t* report, size_t len)
+{
+    if (!Serial) return;   // Serial not initialized
+
+    Serial.println("=== HID Report Dump ===");
+    for (size_t i = 0; i < len; i++)
+    {
+        Serial.printf("%02X ", report[i]);
+        // Optional: break line every 16 bytes
+        if ((i + 1) % 16 == 0) Serial.println();
+    }
+    Serial.println();
+    Serial.println("======================");
+}
 #endif
 
 void BleGamepad::beginNUS() 
@@ -2080,14 +2091,6 @@ void BleGamepad::taskServer(void *pvParameter)
   uint8_t *customHidReportDescriptor = new uint8_t[BleGamepadInstance->hidReportDescriptorSize];
   memcpy(customHidReportDescriptor, BleGamepadInstance->tempHidReportDescriptor, BleGamepadInstance->hidReportDescriptorSize);
 
-  // Testing - Ask ChatGPT to convert it into a commented HID descriptor
-  //Serial.println("------- HID DESCRIPTOR START -------");
-  //for (int i = 0; i < BleGamepadInstance->hidReportDescriptorSize; i++)
-  //{
-  //    Serial.printf("%02x", customHidReportDescriptor[i]);
-  //    Serial.println();
-  //}
-  //Serial.println("------- HID DESCRIPTOR END -------");
 
   // Print HidReportDescriptor to Serial
   #if BLE_GAMEPAD_DEBUG

--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -1950,7 +1950,6 @@ static void dumpHidReportDescriptor(const uint8_t* desc, size_t size) {
     }
 
     Serial.printf("[BLEGamepad][INFO] HID Report Descriptor size: %u bytes\n", (unsigned)size);
-
     for (size_t i = 0; i < size; i++) {
         if (i % 16 == 0) {
             Serial.printf("\n%03u: ", (unsigned)i);
@@ -1958,6 +1957,16 @@ static void dumpHidReportDescriptor(const uint8_t* desc, size_t size) {
         Serial.printf("%02X ", desc[i]);
     }
     Serial.println("\n[BLEGamepad][INFO] End of HID Report Descriptor");
+
+    Serial.printf("\n\nCopy start under here\n");
+    for (size_t i = 0; i < size; i++) {
+        if (i % 16 == 0) {
+            Serial.printf("\n");
+        }
+        Serial.printf("%02X ", desc[i]);
+    }
+    Serial.println("\nCopy end above here ");
+    Serial.println("\n\nCopy and paste the output above and use a parser such as at https://eleccelerator.com/usbdescreqparser to create a readable HID Report Descriptor\n\n");
 }
 #endif
 

--- a/BleGamepad.h
+++ b/BleGamepad.h
@@ -13,6 +13,11 @@
 #include "BleOutputReceiver.h"
 #include "BleNUS.h"
 
+// Debug enabled, disabled by default
+#ifndef BLE_GAMEPAD_DEBUG
+#define BLE_GAMEPAD_DEBUG 0
+#endif
+
 class BleGamepad
 {
   private:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ESP32-BLE-Gamepad
 
+![Build](https://github.com/lemmingDev/ESP32-BLE-Gamepad/actions/workflows/main.yml/badge.svg)
+![PlatformIO](https://github.com/lemmingDev/ESP32-BLE-Gamepad/actions/workflows/main.yml/platform.svg)
+
+BLE Bluetooth HID GAMEPAD library for ESP32
+
 ## License
 Published under the MIT license. Please see license.txt.
 

--- a/test/ci_build/platformio.ini
+++ b/test/ci_build/platformio.ini
@@ -1,0 +1,21 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_ldf_mode = deep+
+lib_deps =
+  h2zero/NimBLE-Arduino
+  ../../
+build_flags =
+  -D BLE_GAMEPAD_DEBUG=1
+
+[env:lolin_c3_mini]
+platform = espressif32
+board = lolin_c3_mini
+framework = arduino
+lib_ldf_mode = deep+
+lib_deps =
+  h2zero/NimBLE-Arduino
+  ../../
+build_flags =
+  -D BLE_GAMEPAD_DEBUG=1

--- a/test/ci_build/src/main.cpp
+++ b/test/ci_build/src/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * A simple sketch that maps a single pin on the ESP32 to a single button on the controller
+ */
+
+#include <Arduino.h>
+#include <BleGamepad.h> // https://github.com/lemmingDev/ESP32-BLE-Gamepad
+
+#define BUTTONPIN 35 // Pin button is attached to
+
+BleGamepad bleGamepad;
+
+int previousButton1State = HIGH;
+
+void setup()
+{
+    pinMode(BUTTONPIN, INPUT_PULLUP);
+    bleGamepad.begin();
+}
+
+void loop()
+{
+    if (bleGamepad.isConnected())
+    {
+
+        int currentButton1State = digitalRead(BUTTONPIN);
+
+        if (currentButton1State != previousButton1State)
+        {
+            if (currentButton1State == LOW)
+            {
+                bleGamepad.press(BUTTON_1);
+            }
+            else
+            {
+                bleGamepad.release(BUTTON_1);
+            }
+        }
+        previousButton1State = currentButton1State;
+    }
+}


### PR DESCRIPTION
Add a build env ```BLE_GAMEPAD_DEBUG``` to dump the HID Report Descriptor, to make easy HID debugging.