### PR TITLE
chore(ci): remove comment-on-pr, as it does not exist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
 
       # See: https://github.com/arduino/compile-sketches#readme
       - name: Compile sketches
+        id: compile
         uses: arduino/compile-sketches@v1
         with:
           enable-deltas-report: true
@@ -69,10 +70,8 @@ jobs:
             - name: Bounce2
             - source-path: .
 
-      - name: Sketches report size delta
-        # Only run the action when the workflow is triggered by a pull request.
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: arduino/report-size-deltas@v1
+      - name: Upload report size data
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: report-size-data
+          path: ${{ steps.compile.outputs.sizes-json-path }}

--- a/.github/workflows/report-size.yml
+++ b/.github/workflows/report-size.yml
@@ -1,0 +1,41 @@
+---
+name: Report size deltas
+
+'on':
+  workflow_run:
+    workflows: ["Compile Sketches"]
+    types: [ completed ]
+
+permissions: {}
+
+jobs:
+  report:
+    # Only run when the triggering workflow was a pull_request build
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Download size data
+        uses: actions/download-artifact@v6
+        with:
+          name: report-size-data
+
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          # If you rely on full history or special refs, include fetch-depth: 0
+          fetch-depth: 0
+
+      - name: Post size deltas
+        uses: arduino/report-size-deltas@v1
+        with:
+          base-sha: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
+          head-sha: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+          sizes-json-path: sizes.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removed a none-existent option ```comment-on-pr```, should have waited for CI to finish to confirm improvement. 

Still think we have a problem with PRs from forks, but not sure.