### PR TITLE
Change usage of the 8th axis to Dial

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -54,6 +54,7 @@ BleGamepad::BleGamepad(std::string deviceName, std::string deviceManufacturer, u
   _rZ(0),
   _slider1(0),
   _slider2(0),
+  _dial(0),
   _rudder(0),
   _throttle(0),
   _accelerator(0),
@@ -430,6 +431,13 @@ void BleGamepad::begin(BleGamepadConfiguration *config)
       // USAGE (Slider)
       tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
       tempHidReportDescriptor[hidReportDescriptorSize++] = 0x36;
+    }
+
+    if (configuration.getIncludeDial())
+    {
+      // USAGE (Dial)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x37;
     }
 
     // INPUT (Data,Var,Abs)
@@ -981,6 +989,12 @@ void BleGamepad::sendReport(void)
       m[currentReportIndex++] = (_slider2 >> 8);
     }
 
+    if (configuration.getIncludeDial())
+    {
+      m[currentReportIndex++] = _dial;
+      m[currentReportIndex++] = (_dial >> 8);
+    }
+
     if (configuration.getIncludeRudder())
     {
       m[currentReportIndex++] = _rudder;
@@ -1509,6 +1523,21 @@ void BleGamepad::setSlider2(int16_t slider2)
   }
 
   _slider2 = slider2;
+
+  if (configuration.getAutoReport())
+  {
+    sendReport();
+  }
+}
+
+void BleGamepad::setDial(int16_t dial)
+{
+  if (dial == -32768)
+  {
+    dial = -32767;
+  }
+
+  _dial = dial;
 
   if (configuration.getAutoReport())
   {

--- a/BleGamepad.h
+++ b/BleGamepad.h
@@ -39,6 +39,7 @@ class BleGamepad
     int16_t _rZ;
     int16_t _slider1;
     int16_t _slider2;
+    int16_t _dial;
     int16_t _rudder;
     int16_t _throttle;
     int16_t _accelerator;
@@ -126,6 +127,7 @@ class BleGamepad
     void setSlider(int16_t slider = 0);
     void setSlider1(int16_t slider1 = 0);
     void setSlider2(int16_t slider2 = 0);
+    void setDial(int16_t dial = 0);
     void setRudder(int16_t rudder = 0);
     void setThrottle(int16_t throttle = 0);
     void setAccelerator(int16_t accelerator = 0);

--- a/BleGamepadConfiguration.cpp
+++ b/BleGamepadConfiguration.cpp
@@ -8,6 +8,7 @@ BleGamepadConfiguration::BleGamepadConfiguration() : _controllerType(CONTROLLER_
                                                      _whichSpecialButtons{false, false, false, false, false, false, false, false},
                                                      _whichAxes{true, true, true, true, true, true, true, true},
                                                      _whichSimulationControls{false, false, false, false, false},
+                                                     _includeDial(false),
                                                      _includeGyroscope(false),
                                                      _includeAccelerometer(false),
                                                      _vid(0xe502),
@@ -117,6 +118,7 @@ bool BleGamepadConfiguration::getIncludeRyAxis() { return _whichAxes[RY_AXIS]; }
 bool BleGamepadConfiguration::getIncludeRzAxis() { return _whichAxes[RZ_AXIS]; }
 bool BleGamepadConfiguration::getIncludeSlider1() { return _whichAxes[SLIDER1]; }
 bool BleGamepadConfiguration::getIncludeSlider2() { return _whichAxes[SLIDER2]; }
+bool BleGamepadConfiguration::getIncludeDial() { return _includeDial; }
 const bool *BleGamepadConfiguration::getWhichAxes() const { return _whichAxes; }
 bool BleGamepadConfiguration::getIncludeRudder() { return _whichSimulationControls[RUDDER]; }
 bool BleGamepadConfiguration::getIncludeThrottle() { return _whichSimulationControls[THROTTLE]; }
@@ -190,6 +192,7 @@ void BleGamepadConfiguration::setIncludeRxAxis(bool value) { _whichAxes[RX_AXIS]
 void BleGamepadConfiguration::setIncludeRyAxis(bool value) { _whichAxes[RY_AXIS] = value; }
 void BleGamepadConfiguration::setIncludeSlider1(bool value) { _whichAxes[SLIDER1] = value; }
 void BleGamepadConfiguration::setIncludeSlider2(bool value) { _whichAxes[SLIDER2] = value; }
+void BleGamepadConfiguration::setIncludeDial(bool value) { _includeDial = value; }
 void BleGamepadConfiguration::setIncludeRudder(bool value) { _whichSimulationControls[RUDDER] = value; }
 void BleGamepadConfiguration::setIncludeThrottle(bool value) { _whichSimulationControls[THROTTLE] = value; }
 void BleGamepadConfiguration::setIncludeAccelerator(bool value) { _whichSimulationControls[ACCELERATOR] = value; }

--- a/BleGamepadConfiguration.h
+++ b/BleGamepadConfiguration.h
@@ -221,6 +221,7 @@ private:
     bool _whichSpecialButtons[POSSIBLESPECIALBUTTONS];
     bool _whichAxes[POSSIBLEAXES];
     bool _whichSimulationControls[POSSIBLESIMULATIONCONTROLS];
+    bool _includeDial;
     bool _includeGyroscope;
     bool _includeAccelerometer;
     uint16_t _vid;
@@ -273,6 +274,7 @@ public:
     bool getIncludeRzAxis();
     bool getIncludeSlider1();
     bool getIncludeSlider2();
+    bool getIncludeDial();
     const bool *getWhichAxes() const;
     bool getIncludeRudder();
     bool getIncludeThrottle();
@@ -323,6 +325,7 @@ public:
     void setIncludeRzAxis(bool value);
     void setIncludeSlider1(bool value);
     void setIncludeSlider2(bool value);
+    void setIncludeDial(bool value);
     void setWhichAxes(bool xAxis, bool yAxis, bool zAxis, bool rxAxis, bool ryAxis, bool rzAxis, bool slider1, bool slider2);
     void setIncludeRudder(bool value);
     void setIncludeThrottle(bool value);


### PR DESCRIPTION
I can't get the 8th axis to work when connected to Linux (did not try other OS). I suspect it is caused by the last two axes sharing the same usage (0x36 Slider). Don't understand HID enough to claim this is wrong, but the same device can also be connected via USB where the 8th axis works and this is the most striking difference in the report descriptor.

This patch changes the second slider to be actually 0x37 Dial. Haven't managed to test this yet, opening the PR mostly so I don't forget. Some details: ExpressLRS/ExpressLRS#2136

btw can you please publish the `7.4` git tag?