### PR TITLE
remove exception

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -1091,9 +1091,9 @@ void BleGamepad::release(uint8_t b)
 
 uint8_t BleGamepad::specialButtonBitPosition(uint8_t b)
 {
-  if (b >= POSSIBLESPECIALBUTTONS)
-    throw std::invalid_argument("Index out of range");
   uint8_t bit = 0;
+  if (b >= POSSIBLESPECIALBUTTONS)
+    return bit;
 
   for (int i = 0; i < b; i++)
   {


### PR DESCRIPTION
Modify specialButtonBitPosition to handle out of range index without throwing an exception.
(it is the only exception in the project, removing it would increase compatibility with other projects where due to a memory or performance restrictions exceptions can not be used)