### PR TITLE
Put sliders into their own logical collections

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -368,9 +368,10 @@ void BleGamepad::begin(BleGamepadConfiguration *config)
     tempHidReportDescriptor[hidReportDescriptorSize++] = 0x75;
     tempHidReportDescriptor[hidReportDescriptorSize++] = 0x10;
 
-    // REPORT_COUNT (configuration.getAxisCount())
+    // REPORT_COUNT (configuration.getAxisCount() - sliders)
+    uint8_t sliders = (configuration.getIncludeSlider1() ? 1 : 0) + (configuration.getIncludeSlider2() ? 1 : 0);
     tempHidReportDescriptor[hidReportDescriptorSize++] = 0x95;
-    tempHidReportDescriptor[hidReportDescriptorSize++] = configuration.getAxisCount();
+    tempHidReportDescriptor[hidReportDescriptorSize++] = configuration.getAxisCount() - sliders;
 
     // COLLECTION (Physical)
     tempHidReportDescriptor[hidReportDescriptorSize++] = 0xA1;
@@ -418,23 +419,53 @@ void BleGamepad::begin(BleGamepadConfiguration *config)
       tempHidReportDescriptor[hidReportDescriptorSize++] = 0x34;
     }
 
+    // INPUT (Data,Var,Abs)
+    tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
+    tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
+
     if (configuration.getIncludeSlider1())
     {
+      // REPORT_COUNT (1)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x95;
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
+
+      // COLLECTION (Logical)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0xA1;
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
+
       // USAGE (Slider)
       tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
       tempHidReportDescriptor[hidReportDescriptorSize++] = 0x36;
+
+      // INPUT (Data,Var,Abs)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
+
+      // END_COLLECTION (Logical)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0xC0;
     }
 
     if (configuration.getIncludeSlider2())
     {
+      // REPORT_COUNT (1)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x95;
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
+
+      // COLLECTION (Logical)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0xA1;
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
+
       // USAGE (Slider)
       tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
       tempHidReportDescriptor[hidReportDescriptorSize++] = 0x36;
-    }
 
-    // INPUT (Data,Var,Abs)
-    tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
-    tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
+      // INPUT (Data,Var,Abs)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
+
+      // END_COLLECTION (Logical)
+      tempHidReportDescriptor[hidReportDescriptorSize++] = 0xC0;
+    }
 
     // END_COLLECTION (Physical)
     tempHidReportDescriptor[hidReportDescriptorSize++] = 0xc0;


### PR DESCRIPTION
After doing some investigation on the multiple slider issue for windows, I have found that wrapping each slider in their own "logical collection" in the HID fixes the issue on Windows systems. I have also tested on MacOS and it too continues to function correctly.

I believe this is the correct for #309 rather than changing the second slider to a Dial.

Referred from https://github.com/ExpressLRS/ExpressLRS/issues/2136 and now https://github.com/ExpressLRS/ExpressLRS/issues/3604

With this fix in place ExpressLRS gets all the 8 full resolution channels on all platforms.