### PR TITLE
Extend the NUS services for external connection, plus add Diagnostics.ino example

### DIFF
--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -1,5 +1,6 @@
 #include "BleConnectionStatus.h"
 #include "NimBLELog.h"
+#include "NimBLEAdvertising.h"
 
 static const char* LOG_TAG = "BleConnectionStatus";
 
@@ -10,17 +11,36 @@ BleConnectionStatus::BleConnectionStatus(void)
 void BleConnectionStatus::onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo)
 {
     NIMBLE_LOGD(LOG_TAG, "onConnect - Connected Address: %s", std::string(connInfo.getAddress()).c_str());
+    Serial.printf("[BLE] Device connecting: %s (handle %u, %u total connected)\n",
+                  std::string(connInfo.getAddress()).c_str(), connInfo.getConnHandle(), pServer->getConnectedCount());
     pServer->updateConnParams(connInfo.getConnHandle(), 6, 7, 0, 600);
+
+    // Keep advertising so additional centrals (e.g. a diagnostics client on the
+    // NUS service) can connect alongside whichever peer is already connected.
+    if (pServer->getConnectedCount() < CONFIG_BT_NIMBLE_MAX_CONNECTIONS)
+    {
+        NIMBLE_LOGD(LOG_TAG, "onConnect - Restarting advertising to allow additional connections");
+        pServer->getAdvertising()->start();
+    }
 }
 
 void BleConnectionStatus::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason)
 {
     NIMBLE_LOGD(LOG_TAG, "onDisconnectConnect - Disconnected Address: %s", std::string(connInfo.getAddress()).c_str());
-    this->connected = false;
+    this->authenticatedConnHandles.erase(connInfo.getConnHandle());
+    this->connected = !this->authenticatedConnHandles.empty();
 }
 
 void BleConnectionStatus::onAuthenticationComplete(NimBLEConnInfo& connInfo)
 {
     NIMBLE_LOGD(LOG_TAG, "onAuthenticationComplete - Authenticated Address: %s", std::string(connInfo.getAddress()).c_str());
+    this->authenticatedConnHandles.insert(connInfo.getConnHandle());
     this->connected = true;
+}
+
+void BleConnectionStatus::onSubscribe(NimBLECharacteristic *pCharacteristic, NimBLEConnInfo &connInfo, uint16_t subValue)
+{
+    const char *action = subValue == 0 ? "unsubscribed from" : "subscribed to";
+    Serial.printf("[BLE] %s %s the Gamepad HID input report (profile: gamepad)\n",
+                  std::string(connInfo.getAddress()).c_str(), action);
 }

--- a/BleConnectionStatus.h
+++ b/BleConnectionStatus.h
@@ -6,11 +6,13 @@
 #include "nimconfig.h"
 #if defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
 
+#include <Arduino.h>
 #include <NimBLEServer.h>
 #include "NimBLECharacteristic.h"
 #include "NimBLEConnInfo.h"
+#include <set>
 
-class BleConnectionStatus : public NimBLEServerCallbacks
+class BleConnectionStatus : public NimBLEServerCallbacks, public NimBLECharacteristicCallbacks
 {
 public:
     BleConnectionStatus(void);
@@ -18,7 +20,16 @@ public:
     void onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo) override;
     void onDisconnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo, int reason) override;
     void onAuthenticationComplete(NimBLEConnInfo& connInfo) override;
+
+    // Registered as the characteristic callback for the HID input report, so we can
+    // log when a peer subscribes to it - the real signal that it wants the gamepad
+    // profile, as opposed to (say) only the NUS service.
+    void onSubscribe(NimBLECharacteristic *pCharacteristic, NimBLEConnInfo &connInfo, uint16_t subValue) override;
+
     NimBLECharacteristic *inputGamepad;
+
+private:
+    std::set<uint16_t> authenticatedConnHandles;
 };
 
 #endif // CONFIG_BT_NIMBLE_ROLE_PERIPHERAL

--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -2075,6 +2075,7 @@ void BleGamepad::taskServer(void *pvParameter)
 
   BleGamepadInstance->inputGamepad = BleGamepadInstance->hid->getInputReport(BleGamepadInstance->configuration.getHidReportId()); // <-- input REPORTID from report map
   BleGamepadInstance->connectionStatus->inputGamepad = BleGamepadInstance->inputGamepad;
+  BleGamepadInstance->inputGamepad->setCallbacks(BleGamepadInstance->connectionStatus); // Logs which peer subscribes to the gamepad profile
 
   if (BleGamepadInstance->enableOutputReport) 
   {

--- a/BleNUS.cpp
+++ b/BleNUS.cpp
@@ -10,8 +10,8 @@
 static const char *LOG_TAG = "BleNUS";
 #endif
 
-BleNUS::BleNUS(NimBLEServer* existingServer) 
-    : pServer(existingServer), pService(nullptr), pTxCharacteristic(nullptr), pRxCharacteristic(nullptr), dataReceivedCallback(nullptr) {}
+BleNUS::BleNUS(NimBLEServer* existingServer)
+    : pServer(existingServer), pService(nullptr), pTxCharacteristic(nullptr), pRxCharacteristic(nullptr), dataReceivedCallback(nullptr), subscribeCallback(nullptr) {}
 
 BleNUS::~BleNUS() {
     end();
@@ -66,14 +66,27 @@ void BleNUS::end() {
 }
 
 void BleNUS::sendData(const uint8_t* data, size_t length) {
-    if (pTxCharacteristic && pServer->getConnectedCount() > 0) {
-        pTxCharacteristic->setValue(data, length);
-        pTxCharacteristic->notify();
+    if (!pTxCharacteristic) {
+        Serial.println("[NUS] sendData: no TX characteristic yet - dropped");
+        return;
     }
+    if (pServer->getConnectedCount() == 0) {
+        Serial.println("[NUS] sendData: no BLE peer connected - dropped");
+        return;
+    }
+
+    pTxCharacteristic->setValue(data, length);
+    bool ok = pTxCharacteristic->notify();
+    Serial.printf("[NUS] sendData: notify(%u bytes) -> %s: \"%.*s\"\n",
+                  (unsigned)length, ok ? "ok" : "FAILED", (int)length, (const char*)data);
 }
 
 void BleNUS::setDataReceivedCallback(void (*callback)(const uint8_t* data, size_t length)) {
     dataReceivedCallback = callback;
+}
+
+void BleNUS::setSubscribeCallback(void (*callback)(bool subscribed, const std::string& address)) {
+    subscribeCallback = callback;
 }
 
 void BleNUS::onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) {
@@ -86,8 +99,12 @@ void BleNUS::onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& conn
 
 void BleNUS::onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue) {
     const char *action = subValue == 0 ? "unsubscribed from" : "subscribed to";
-    Serial.printf("[BLE] %s %s the Nordic UART Service (profile: NUS)\n",
-                  std::string(connInfo.getAddress()).c_str(), action);
+    std::string address = std::string(connInfo.getAddress());
+    Serial.printf("[BLE] %s %s the Nordic UART Service (profile: NUS)\n", address.c_str(), action);
+
+    if (subscribeCallback) {
+        subscribeCallback(subValue != 0, address);
+    }
 }
 
 size_t BleNUS::available() {
@@ -155,9 +172,15 @@ void BleNUS::print(char c) {
     print(buf);
 }
 
+// Each println() sends exactly one notification containing the text plus its trailing
+// newline. Sending the newline as a second, separate notify() (as print(str); print("\n");
+// would) means BLE clients that only surface the latest notification value - e.g. LightBlue's
+// characteristic view - only ever show a lone 0x0A, since it overwrites the real text an
+// instant later.
 void BleNUS::println(const char* str) {
-    print(str);
-    print("\n");
+    std::string message(str);
+    message += "\n";
+    sendData((const uint8_t*)message.data(), message.length());
 }
 
 void BleNUS::println(const String& str) {
@@ -165,32 +188,40 @@ void BleNUS::println(const String& str) {
 }
 
 void BleNUS::println(int i) {
-    print(i);
-    print("\n");
+    char buf[33];
+    itoa(i, buf, 10);
+    strcat(buf, "\n");
+    sendData((const uint8_t*)buf, strlen(buf));
 }
 
 void BleNUS::println(long l) {
-    print(l);
-    print("\n");
+    char buf[33];
+    ltoa(l, buf, 10);
+    strcat(buf, "\n");
+    sendData((const uint8_t*)buf, strlen(buf));
 }
 
 void BleNUS::println(unsigned long ul) {
-    print(ul);
-    print("\n");
+    char buf[33];
+    ultoa(ul, buf, 10);
+    strcat(buf, "\n");
+    sendData((const uint8_t*)buf, strlen(buf));
 }
 
 void BleNUS::println(float f, int digits) {
-    print(f, digits);
-    print("\n");
+    char buf[33];
+    dtostrf(f, 6, digits, buf);
+    strcat(buf, "\n");
+    sendData((const uint8_t*)buf, strlen(buf));
 }
 
 void BleNUS::println(double d, int digits) {
-    print(d, digits);
-    print("\n");
+    println((float)d, digits);
 }
 
 void BleNUS::println(char c) {
-    print(c);
+    char buf[3] = {c, '\n', '\0'};
+    sendData((const uint8_t*)buf, 2);
     print("\n");
 }
 

--- a/BleNUS.cpp
+++ b/BleNUS.cpp
@@ -90,9 +90,13 @@ void BleNUS::setSubscribeCallback(void (*callback)(bool subscribed, const std::s
 }
 
 void BleNUS::onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) {
+    // Buffering must not depend on dataReceivedCallback being set - main.cpp uses the
+    // polling available()/read() API instead, and never registers a callback, so gating
+    // this on dataReceivedCallback silently dropped every incoming write.
+    std::string value = pCharacteristic->getValue();
+    buffer += value; // Append to internal buffer
+
     if (dataReceivedCallback) {
-        std::string value = pCharacteristic->getValue();
-        buffer += value; // Append to internal buffer
         dataReceivedCallback((const uint8_t*)value.data(), value.length());
     }
 }
@@ -222,7 +226,6 @@ void BleNUS::println(double d, int digits) {
 void BleNUS::println(char c) {
     char buf[3] = {c, '\n', '\0'};
     sendData((const uint8_t*)buf, 2);
-    print("\n");
 }
 
 void BleNUS::write(uint8_t byte) {

--- a/BleNUS.cpp
+++ b/BleNUS.cpp
@@ -37,6 +37,7 @@ void BleNUS::begin() {
     pRxCharacteristic = pService->createCharacteristic(NUS_RX_CHARACTERISTIC_UUID, NIMBLE_PROPERTY::WRITE);
     NIMBLE_LOGD(LOG_TAG, "Registering Nordic UART Service callbacks");
     pRxCharacteristic->setCallbacks(this);
+    pTxCharacteristic->setCallbacks(this); // Logs which peer subscribes to the NUS profile
     
     NIMBLE_LOGD(LOG_TAG, "Starting Nordic UART Service");
     pService->start();
@@ -81,6 +82,12 @@ void BleNUS::onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& conn
         buffer += value; // Append to internal buffer
         dataReceivedCallback((const uint8_t*)value.data(), value.length());
     }
+}
+
+void BleNUS::onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue) {
+    const char *action = subValue == 0 ? "unsubscribed from" : "subscribed to";
+    Serial.printf("[BLE] %s %s the Nordic UART Service (profile: NUS)\n",
+                  std::string(connInfo.getAddress()).c_str(), action);
 }
 
 size_t BleNUS::available() {

--- a/BleNUS.h
+++ b/BleNUS.h
@@ -1,6 +1,7 @@
 #ifndef BleNUS_h
 #define BleNUS_h
 
+#include <Arduino.h>
 #include <NimBLEDevice.h>
 
 #define NUS_SERVICE_UUID "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
@@ -46,6 +47,7 @@ public:
     void write(const uint8_t *buffer, size_t size);
     
     void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) override;
+    void onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue) override;
 
 private:
     NimBLEServer* pServer;

--- a/BleNUS.h
+++ b/BleNUS.h
@@ -19,6 +19,7 @@ public:
     void sendData(const uint8_t* data, size_t length);
     
     void setDataReceivedCallback(void (*callback)(const uint8_t* data, size_t length));
+    void setSubscribeCallback(void (*callback)(bool subscribed, const std::string& address));
     
     size_t available();
     int read();
@@ -56,6 +57,7 @@ private:
     NimBLECharacteristic* pRxCharacteristic;
     
     void (*dataReceivedCallback)(const uint8_t* data, size_t length);
+    void (*subscribeCallback)(bool subscribed, const std::string& address);
     std::string buffer; // For storing received data
 };
 

--- a/examples/Diagnostics/Diagnostics.ino
+++ b/examples/Diagnostics/Diagnostics.ino
@@ -115,57 +115,63 @@ void loop()
         digitalWrite(LED_BUILTIN, ledState);
     }
 
+    // A NUS-only client (e.g. a terminal app that connects and subscribes without ever
+    // bonding, since NUS doesn't require the encryption the HID profile does) can be fully
+    // reachable over NUS while bleGamepad.isConnected() (gamepad HID authentication) is still
+    // false. So NUS input/output below must not be gated on `connected` - only the gamepad-
+    // specific behaviours (button auto-press, battery reporting) are.
+    BleNUS *nus = bleGamepad.getNUS();
+
     if (!connected)
     {
         buttonHeld = false;
         button4Held = false;
-        return;
     }
-
-    BleNUS *nus = bleGamepad.getNUS();
-
-    // --- Auto-press BUTTON_3 every 10s, releasing it 0.5s later ---
-    if (!buttonHeld && millis() - lastButtonPressTime >= BUTTON_PRESS_INTERVAL_MS)
+    else
     {
-        lastButtonPressTime = millis();
-        buttonPressStartTime = lastButtonPressTime;
-        buttonHeld = true;
-        bleGamepad.press(BUTTON_3);
-    }
-    else if (buttonHeld && millis() - buttonPressStartTime >= BUTTON_HOLD_MS)
-    {
-        buttonHeld = false;
-        bleGamepad.release(BUTTON_3);
-    }
-
-    // --- Release BUTTON_4 once its 5s NUS-triggered hold has elapsed ---
-    if (button4Held && millis() - button4PressStartTime >= BUTTON4_HOLD_MS)
-    {
-        button4Held = false;
-        bleGamepad.release(BUTTON_4);
-        if (nus)
+        // --- Auto-press BUTTON_3 every 10s, releasing it 0.5s later ---
+        if (!buttonHeld && millis() - lastButtonPressTime >= BUTTON_PRESS_INTERVAL_MS)
         {
-            nus->println("BUTTON_4 released after 5s hold.");
+            lastButtonPressTime = millis();
+            buttonPressStartTime = lastButtonPressTime;
+            buttonHeld = true;
+            bleGamepad.press(BUTTON_3);
         }
-    }
-
-    // --- Ramp the reported battery level up and down between 25% and 95% ---
-    if (millis() - lastBatteryStepTime >= BATTERY_STEP_INTERVAL_MS)
-    {
-        lastBatteryStepTime = millis();
-
-        batteryLevel += batteryStep;
-        if (batteryLevel >= BATTERY_MAX)
+        else if (buttonHeld && millis() - buttonPressStartTime >= BUTTON_HOLD_MS)
         {
-            batteryLevel = BATTERY_MAX;
-            batteryStep = -1;
+            buttonHeld = false;
+            bleGamepad.release(BUTTON_3);
         }
-        else if (batteryLevel <= BATTERY_MIN)
+
+        // --- Release BUTTON_4 once its 5s NUS-triggered hold has elapsed ---
+        if (button4Held && millis() - button4PressStartTime >= BUTTON4_HOLD_MS)
         {
-            batteryLevel = BATTERY_MIN;
-            batteryStep = 1;
+            button4Held = false;
+            bleGamepad.release(BUTTON_4);
+            if (nus)
+            {
+                nus->println("BUTTON_4 released after 5s hold.");
+            }
         }
-        bleGamepad.setBatteryLevel(batteryLevel);
+
+        // --- Ramp the reported battery level up and down between 25% and 95% ---
+        if (millis() - lastBatteryStepTime >= BATTERY_STEP_INTERVAL_MS)
+        {
+            lastBatteryStepTime = millis();
+
+            batteryLevel += batteryStep;
+            if (batteryLevel >= BATTERY_MAX)
+            {
+                batteryLevel = BATTERY_MAX;
+                batteryStep = -1;
+            }
+            else if (batteryLevel <= BATTERY_MIN)
+            {
+                batteryLevel = BATTERY_MIN;
+                batteryStep = 1;
+            }
+            bleGamepad.setBatteryLevel(batteryLevel);
+        }
     }
 
     if (!nus)
@@ -219,6 +225,8 @@ void loop()
         lastStatusTime = millis();
 
         String status = "uptime_ms=" + String(millis()) +
+                         " gamepad_connected=" + (bleGamepad.isConnected() ? "yes" : "no") +
+                         " host_mac=" + String(bleGamepad.getAddress().toString().c_str()) +
                          " button3=" + (buttonHeld ? "PRESSED" : "released") +
                          " button4=" + (button4Held ? "PRESSED" : "released") +
                          " battery=" + String(batteryLevel) +

--- a/examples/Diagnostics/Diagnostics.ino
+++ b/examples/Diagnostics/Diagnostics.ino
@@ -90,6 +90,7 @@ void setup()
 
     bleGamepadConfig.setButtonCount(8); // covers BUTTON_1..BUTTON_8
     //bleGamepadConfig.setHatSwitchCount(0);
+    // Need one HAT or else gaempad is not registered on Android. The hat is never used, so just leave it at 1.
     bleGamepadConfig.setHatSwitchCount(1);
     bleGamepadConfig.setWhichAxes(false, false, false, false, false, false, false, false);
 

--- a/examples/Diagnostics/Diagnostics.ino
+++ b/examples/Diagnostics/Diagnostics.ino
@@ -1,63 +1,178 @@
 /*
- * A minimal single-button gamepad with the Nordic UART Service (NUS) also enabled.
+ * An auto-pressing gamepad with the Nordic UART Service (NUS) also enabled.
  * Intended as a quick diagnostics tool rather than a real controller: connect any
  * BLE UART terminal app (e.g. "Serial Bluetooth Terminal", nRF Connect) to the same
- * device to see a live status line and to test that the NUS RX/TX path works -
- * anything you send is echoed straight back.
+ * device. As soon as it subscribes to NUS notifications it gets a greeting, then a
+ * status line proactively every few seconds (not just replies to what it sends) -
+ * this confirms the NUS TX path works without needing any input. Anything sent that
+ * isn't a recognised command is echoed straight back; send "help" for the list of
+ * commands.
+ *
+ * BUTTON_3 is pressed automatically every 10s and released 0.5s later, to test
+ * the gamepad HID path continuously. Sending "button4" over NUS presses and
+ * holds BUTTON_4 for 5s before releasing it, as an on-demand test that NUS
+ * input, NUS output and the gamepad HID path are all working together.
+ *
+ * The reported battery level ramps up and down between 25% and 95%, and the
+ * onboard LED blinks slowly while waiting for a BLE connection and quickly
+ * once connected.
  */
 
 #include <Arduino.h>
 #include <BleGamepad.h> // https://github.com/lemmingDev/ESP32-BLE-Gamepad
 
-#define BUTTONPIN 35            // Pin button is attached to
-#define STATUS_INTERVAL_MS 1000 // How often to send a status line over NUS
+#define STATUS_INTERVAL_MS 3000        // How often to proactively push a status line over NUS
+#define BUTTON_PRESS_INTERVAL_MS 10000 // How often to auto-press BUTTON_3
+#define BUTTON_HOLD_MS 500             // How long BUTTON_3 stays pressed
+#define BUTTON4_HOLD_MS 5000           // How long BUTTON_4 stays pressed when triggered via NUS
+#define BATTERY_STEP_INTERVAL_MS 1000  // How often to step the battery level
+#define BATTERY_MIN 25
+#define BATTERY_MAX 95
+#define LED_BLINK_INTERVAL_DISCONNECTED_MS 1000 // Slow blink while waiting to connect
+#define LED_BLINK_INTERVAL_CONNECTED_MS 150     // Fast blink once connected
 
-BleGamepad bleGamepad;
+// Default name is "ESP32 BLE Gamepad" - shared by every sketch in this workspace that uses
+// the library's default BleGamepad constructor. With more than one board powered on, they're
+// indistinguishable in a scanner and it's easy to connect to the wrong one (e.g. one with no
+// NUS service at all, which looks exactly like "no serial profile found").
+BleGamepad bleGamepad("ESP32 BLE Gamepad Diag");
 
-int previousButtonState = HIGH;
 unsigned long lastStatusTime = 0;
+unsigned long lastButtonPressTime = 0;
+bool buttonHeld = false;
+unsigned long buttonPressStartTime = 0;
+
+bool button4Held = false;
+unsigned long button4PressStartTime = 0;
+
+uint8_t batteryLevel = BATTERY_MIN;
+int8_t batteryStep = 1;
+unsigned long lastBatteryStepTime = 0;
+
+bool ledState = false;
+unsigned long lastLedToggleTime = 0;
+
+// Fires when a central subscribes/unsubscribes to NUS TX notifications - this is the
+// real "NUS is connected" signal, separate from the general BLE link (a central can be
+// connected without ever subscribing, in which case NUS pushes would silently go nowhere).
+void onNusSubscribeChanged(bool subscribed, const std::string &address)
+{
+    Serial.printf("[NUS] %s %s (free_heap=%u)\n", address.c_str(),
+                  subscribed ? "subscribed - NUS output will now reach it" : "unsubscribed",
+                  ESP.getFreeHeap());
+
+    if (subscribed)
+    {
+        BleNUS *nus = bleGamepad.getNUS();
+        if (nus)
+        {
+            nus->println("[NUS] Subscribed. Send 'help' for a list of commands.");
+        }
+    }
+}
 
 void setup()
 {
     Serial.begin(115200);
-    pinMode(BUTTONPIN, INPUT_PULLUP);
+    pinMode(LED_BUILTIN, OUTPUT);
 
-    bleGamepad.begin();
+    // The library's default config reports 16 buttons, a hat switch and all 8 axes.
+    // This sketch only ever presses BUTTON_3/BUTTON_4, so trim the HID descriptor down
+    // to just those - the oversized default was causing button presses to be
+    // misread by Android's gamepad parser (report offsets shifted, wrong button lit).
+    // CONTROLLER_TYPE_JOYSTICK was tried here to chase a button-mapping mismatch, but it
+    // changes the top-level HID usage from "Game Pad" (0x05) to "Joystick" (0x04), which is
+    // why Android/the gamepad tester stopped recognising it as a gamepad (SOURCE_JOYSTICK
+    // instead of SOURCE_GAMEPAD). Keep GAMEPAD - the button mismatch needs a different fix.
+    BleGamepadConfiguration bleGamepadConfig;
+    //bleGamepadConfig.setControllerType(CONTROLLER_TYPE_GAMEPAD);
+    //bleGamepadConfig.setControllerType(CONTROLLER_TYPE_JOYSTICK);
+
+    bleGamepadConfig.setButtonCount(8); // covers BUTTON_1..BUTTON_8
+    //bleGamepadConfig.setHatSwitchCount(0);
+    bleGamepadConfig.setHatSwitchCount(1);
+    bleGamepadConfig.setWhichAxes(false, false, false, false, false, false, false, false);
+
+    bleGamepad.begin(&bleGamepadConfig);
     bleGamepad.beginNUS(); // Adds the Nordic UART Service alongside the gamepad HID service
+    bleGamepad.getNUS()->setSubscribeCallback(onNusSubscribeChanged);
+    bleGamepad.setBatteryLevel(batteryLevel);
 
-    Serial.println("[Diagnostics] Ready - waiting for a BLE connection.");
+    Serial.println("[Diagnostics] Ready - waiting for a BLE connection. Send 'help' over NUS once connected for a list of commands.");
 }
 
 void loop()
 {
-    if (!bleGamepad.isConnected())
+    bool connected = bleGamepad.isConnected();
+
+    // --- LED: slow blink while disconnected, fast blink while connected ---
+    unsigned long ledInterval = connected ? LED_BLINK_INTERVAL_CONNECTED_MS : LED_BLINK_INTERVAL_DISCONNECTED_MS;
+    if (millis() - lastLedToggleTime >= ledInterval)
     {
-        previousButtonState = HIGH;
+        lastLedToggleTime = millis();
+        ledState = !ledState;
+        digitalWrite(LED_BUILTIN, ledState);
+    }
+
+    if (!connected)
+    {
+        buttonHeld = false;
+        button4Held = false;
         return;
     }
 
-    // --- Button handling (same pattern as the SingleButton example) ---
-    int currentButtonState = digitalRead(BUTTONPIN);
-    if (currentButtonState != previousButtonState)
+    BleNUS *nus = bleGamepad.getNUS();
+
+    // --- Auto-press BUTTON_3 every 10s, releasing it 0.5s later ---
+    if (!buttonHeld && millis() - lastButtonPressTime >= BUTTON_PRESS_INTERVAL_MS)
     {
-        if (currentButtonState == LOW)
+        lastButtonPressTime = millis();
+        buttonPressStartTime = lastButtonPressTime;
+        buttonHeld = true;
+        bleGamepad.press(BUTTON_3);
+    }
+    else if (buttonHeld && millis() - buttonPressStartTime >= BUTTON_HOLD_MS)
+    {
+        buttonHeld = false;
+        bleGamepad.release(BUTTON_3);
+    }
+
+    // --- Release BUTTON_4 once its 5s NUS-triggered hold has elapsed ---
+    if (button4Held && millis() - button4PressStartTime >= BUTTON4_HOLD_MS)
+    {
+        button4Held = false;
+        bleGamepad.release(BUTTON_4);
+        if (nus)
         {
-            bleGamepad.press(BUTTON_1);
-        }
-        else
-        {
-            bleGamepad.release(BUTTON_1);
+            nus->println("BUTTON_4 released after 5s hold.");
         }
     }
-    previousButtonState = currentButtonState;
 
-    BleNUS *nus = bleGamepad.getNUS();
+    // --- Ramp the reported battery level up and down between 25% and 95% ---
+    if (millis() - lastBatteryStepTime >= BATTERY_STEP_INTERVAL_MS)
+    {
+        lastBatteryStepTime = millis();
+
+        batteryLevel += batteryStep;
+        if (batteryLevel >= BATTERY_MAX)
+        {
+            batteryLevel = BATTERY_MAX;
+            batteryStep = -1;
+        }
+        else if (batteryLevel <= BATTERY_MIN)
+        {
+            batteryLevel = BATTERY_MIN;
+            batteryStep = 1;
+        }
+        bleGamepad.setBatteryLevel(batteryLevel);
+    }
+
     if (!nus)
     {
         return;
     }
 
-    // --- Echo anything received back over NUS, to confirm the RX path works ---
+    // --- Handle commands received over NUS ---
     if (nus->available())
     {
         String received;
@@ -65,7 +180,36 @@ void loop()
         {
             received += (char)nus->read();
         }
-        nus->println("Echo: " + received);
+
+        String command = received;
+        command.trim();
+        command.toLowerCase();
+
+        if (command == "help")
+        {
+            nus->println("Available commands:");
+            nus->println("  help     - show this help message");
+            nus->println("  button4  - press BUTTON_4 for 5s (tests NUS input/output + gamepad HID)");
+            nus->println("Anything else is echoed straight back.");
+        }
+        else if (command == "button4")
+        {
+            if (!button4Held)
+            {
+                button4Held = true;
+                button4PressStartTime = millis();
+                bleGamepad.press(BUTTON_4);
+                nus->println("BUTTON_4 pressed - will release in 5s.");
+            }
+            else
+            {
+                nus->println("BUTTON_4 is already held.");
+            }
+        }
+        else
+        {
+            nus->println("Echo: " + received);
+        }
     }
 
     // --- Periodic status line over NUS, to confirm the TX path works ---
@@ -74,7 +218,9 @@ void loop()
         lastStatusTime = millis();
 
         String status = "uptime_ms=" + String(millis()) +
-                         " button1=" + (currentButtonState == LOW ? "PRESSED" : "released") +
+                         " button3=" + (buttonHeld ? "PRESSED" : "released") +
+                         " button4=" + (button4Held ? "PRESSED" : "released") +
+                         " battery=" + String(batteryLevel) +
                          " free_heap=" + String(ESP.getFreeHeap());
         nus->println(status);
         Serial.println(status);

--- a/examples/Diagnostics/Diagnostics.ino
+++ b/examples/Diagnostics/Diagnostics.ino
@@ -1,0 +1,82 @@
+/*
+ * A minimal single-button gamepad with the Nordic UART Service (NUS) also enabled.
+ * Intended as a quick diagnostics tool rather than a real controller: connect any
+ * BLE UART terminal app (e.g. "Serial Bluetooth Terminal", nRF Connect) to the same
+ * device to see a live status line and to test that the NUS RX/TX path works -
+ * anything you send is echoed straight back.
+ */
+
+#include <Arduino.h>
+#include <BleGamepad.h> // https://github.com/lemmingDev/ESP32-BLE-Gamepad
+
+#define BUTTONPIN 35            // Pin button is attached to
+#define STATUS_INTERVAL_MS 1000 // How often to send a status line over NUS
+
+BleGamepad bleGamepad;
+
+int previousButtonState = HIGH;
+unsigned long lastStatusTime = 0;
+
+void setup()
+{
+    Serial.begin(115200);
+    pinMode(BUTTONPIN, INPUT_PULLUP);
+
+    bleGamepad.begin();
+    bleGamepad.beginNUS(); // Adds the Nordic UART Service alongside the gamepad HID service
+
+    Serial.println("[Diagnostics] Ready - waiting for a BLE connection.");
+}
+
+void loop()
+{
+    if (!bleGamepad.isConnected())
+    {
+        previousButtonState = HIGH;
+        return;
+    }
+
+    // --- Button handling (same pattern as the SingleButton example) ---
+    int currentButtonState = digitalRead(BUTTONPIN);
+    if (currentButtonState != previousButtonState)
+    {
+        if (currentButtonState == LOW)
+        {
+            bleGamepad.press(BUTTON_1);
+        }
+        else
+        {
+            bleGamepad.release(BUTTON_1);
+        }
+    }
+    previousButtonState = currentButtonState;
+
+    BleNUS *nus = bleGamepad.getNUS();
+    if (!nus)
+    {
+        return;
+    }
+
+    // --- Echo anything received back over NUS, to confirm the RX path works ---
+    if (nus->available())
+    {
+        String received;
+        while (nus->available())
+        {
+            received += (char)nus->read();
+        }
+        nus->println("Echo: " + received);
+    }
+
+    // --- Periodic status line over NUS, to confirm the TX path works ---
+    if (millis() - lastStatusTime >= STATUS_INTERVAL_MS)
+    {
+        lastStatusTime = millis();
+
+        String status = "uptime_ms=" + String(millis()) +
+                         " button1=" + (currentButtonState == LOW ? "PRESSED" : "released") +
+                         " free_heap=" + String(ESP.getFreeHeap());
+        nus->println(status);
+        Serial.println(status);
+    }
+}


### PR DESCRIPTION
For my testing, I would like to be able to use another debug device, not the same one connected to the ESP32-BLE-Gamepad hardware.

This updates the NUS service to be connectable from another device using something like ```Serial Bluetooth Terminal``` on Android for debugging and possible changing things.

Also added an example  ```Diagnostics.ino``` sketch that basically works to show debug updates and input from another device.

Looking for feedback, if this is useful for other people. There is no security auth on the NUS services. Also should be an option which by default is off.