### PR TITLE
chore(ci): build a board matrix (S3/C3/C6) and add per-run memory summary

### DIFF
--- a/.github/scripts/report_size_summary.py
+++ b/.github/scripts/report_size_summary.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Render an arduino/compile-sketches JSON size report as a Markdown table
+and append it to the job's GitHub Actions step summary.
+
+Used by .github/workflows/main.yml right after the "Compile sketches" step,
+once per board in the build matrix, so memory usage (and its delta versus
+the previous commit, when available) is visible straight on the workflow
+run page instead of only in the weekly PR delta comment.
+"""
+import argparse
+import glob
+import json
+import os
+
+SIZE_NAMES = [
+    ("flash", "Flash"),
+    ("RAM for global variables", "RAM"),
+]
+
+
+def size_entry(sizes, name):
+    for size in sizes:
+        if size["name"] == name:
+            return size
+    return None
+
+
+def fmt_bytes(n):
+    return f"{n:,}"
+
+
+def fmt_current(size):
+    if size is None:
+        return "n/a"
+    current = size["current"]
+    return f"{fmt_bytes(current['absolute'])} B ({current['relative']:.1f}%)"
+
+
+def fmt_delta(size):
+    if size is None or "delta" not in size:
+        return ""
+    absolute = size["delta"]["absolute"]
+    relative = size["delta"]["relative"]
+    if absolute > 0:
+        return f"+{fmt_bytes(absolute)} B (+{relative:.1f}%) :small_red_triangle:"
+    if absolute < 0:
+        return f"{fmt_bytes(absolute)} B ({relative:.1f}%) :small_red_triangle_down:"
+    return "no change"
+
+
+def render_board(board):
+    lines = [f"## Memory usage — `{board['board']}`", ""]
+
+    sketches = board.get("sketches", [])
+    if not sketches:
+        lines.append("_No sketches compiled._")
+        return lines
+
+    header = ["Sketch"]
+    for _, label in SIZE_NAMES:
+        header += [label, f"Δ {label}"]
+    lines.append(f"| {' | '.join(header)} |")
+    lines.append(f"|{'---|' * len(header)}")
+
+    for sketch in sketches:
+        name = sketch["name"].removeprefix("examples/")
+        if not sketch.get("compilation_success"):
+            row = [name] + [":x: failed", ""] * len(SIZE_NAMES)
+            lines.append(f"| {' | '.join(row)} |")
+            continue
+
+        row = [name]
+        for size_name, _ in SIZE_NAMES:
+            size = size_entry(sketch.get("sizes", []), size_name)
+            row += [fmt_current(size), fmt_delta(size)]
+        lines.append(f"| {' | '.join(row)} |")
+
+    return lines
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reports-dir", required=True)
+    parser.add_argument("--summary-file", required=True)
+    args = parser.parse_args()
+
+    report_paths = sorted(glob.glob(os.path.join(args.reports_dir, "*.json")))
+    if not report_paths:
+        return
+
+    lines = []
+    for report_path in report_paths:
+        with open(report_path) as f:
+            report = json.load(f)
+
+        for board in report.get("boards", []):
+            lines += render_board(board)
+            lines.append("")
+
+    with open(args.summary_file, "a") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,20 @@ jobs:
   compile-sketches:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        board: [esp32, esp32s3, esp32c3, esp32c6]
+        include:
+          - board: esp32
+            fqbn: esp32:esp32:esp32
+          - board: esp32s3
+            fqbn: esp32:esp32:esp32s3
+          - board: esp32c3
+            fqbn: esp32:esp32:esp32c3
+          - board: esp32c6
+            fqbn: esp32:esp32:esp32c6
+
     permissions:
       contents: read        # needed to fetch base commit
       pull-requests: write  # needed to post the delta report
@@ -38,43 +52,52 @@ jobs:
         with:
           fetch-depth: 0    # required for comparing base vs. head commits
 
+      - name: Find example sketches
+        id: find-sketches
+        env:
+          # Sketches known to fail compilation; excluded until fixed.
+          EXCLUDE_SKETCHES: "Diagnostics"
+        run: |
+          {
+            echo 'sketch-paths<<EOF'
+            for dir in examples/*/; do
+              name="$(basename "$dir")"
+              skip=false
+              for excluded in $EXCLUDE_SKETCHES; do
+                if [[ "$name" == "$excluded" ]]; then
+                  skip=true
+                  break
+                fi
+              done
+              [[ "$skip" == true ]] && continue
+              [[ -f "${dir}${name}.ino" ]] && echo "- ${dir%/}"
+            done
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
       # See: https://github.com/arduino/compile-sketches#readme
       - name: Compile sketches
         uses: arduino/compile-sketches@v1
         with:
           enable-deltas-report: true
-          fqbn: esp32:esp32:esp32
+          fqbn: ${{ matrix.fqbn }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          sketch-paths: |
-            - examples/CharacteristicsConfiguration/CharacteristicsConfiguration.ino
-            - examples/DrivingControllerTest/DrivingControllerTest.ino
-            - examples/Fightstick/Fightstick.ino
-            - examples/FlightControllerTest/FlightControllerTest.ino
-            - examples/ForcePairingMode/ForcePairingMode.ino
-            - examples/Gamepad/Gamepad.ino
-            - examples/GetPeerInfo/GetPeerInfo.ino
-            - examples/IndividualAxes/IndividualAxes.ino
-            - examples/Keypad4x4/Keypad4x4.ino
-            - examples/MotionController/MotionController.ino
-            - examples/MultipleButtons/MultipleButtons.ino
-            - examples/MultipleButtonsAndHats/MultipleButtonsAndHats.ino
-            - examples/MultipleButtonsDebounce/MultipleButtonsDebounce.ino
-            - examples/PotAsAxis/PotAsAxis.ino
-            - examples/SetBatteryLevel/SetBatteryLevel.ino
-            - examples/SetBatteryPowerState/SetBatteryPowerState.ino
-            - examples/SingleButton/SingleButton.ino
-            - examples/SingleButtonDebounce/SingleButtonDebounce.ino
-            - examples/SpecialButtons/SpecialButtons.ino
-            - examples/TestAll/TestAll.ino
-            - examples/TestReceivingOutputReport/TestReceivingOutputReport.ino
+          sketch-paths: ${{ steps.find-sketches.outputs.sketch-paths }}
           libraries: |
             - name: NimBLE-Arduino
             - name: Keypad
             - name: Bounce2
             - source-path: .
 
+      - name: Summarize memory usage
+        if: always()
+        run: |
+          python3 .github/scripts/report_size_summary.py \
+            --reports-dir sketches-reports \
+            --summary-file "$GITHUB_STEP_SUMMARY"
+
       - name: Upload report size data
         uses: actions/upload-artifact@v7
         with:
-          name: report-size-data
+          name: report-size-data-${{ matrix.board }}
           path: sketches-reports

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        board: [esp32dev, lolin_c3_mini, esp32s3]
+        board: [esp32dev, lolin_c3_mini, esp32s3, esp32c6]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -26,7 +26,11 @@ jobs:
 
     strategy:
       matrix:
-        board: [esp32dev, esp32s3, esp32c3, esp32c6]
+        # esp32c6 is disabled here: the official "espressif32" PlatformIO
+        # platform doesn't support the arduino framework for it yet (only
+        # espidf). Re-enable once that lands; see the commented-out
+        # [env:esp32c6] in test/ci_build/platformio.ini.
+        board: [esp32dev, esp32s3, esp32c3]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        board: [esp32dev, lolin_c3_mini, esp32s3, esp32c6]
+        board: [esp32dev, esp32s3, esp32c3, esp32c6]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Report size deltas
         uses: arduino/report-size-deltas@v1
         with:
-          # Matches the artifact name uploaded by the "Compile Sketches"
-          # workflow (.github/workflows/main.yml). The action searches
-          # recent workflow runs for artifacts matching this name and
-          # posts a comment on any open PR it can diff a base vs. head
-          # report for; runs with nothing to compare (pushes, the monthly
-          # schedule build) are skipped automatically.
-          sketches-reports-source: report-size-data
+          # Regex matching the per-board artifact names uploaded by the
+          # "Compile Sketches" workflow's build matrix
+          # (.github/workflows/main.yml), e.g. report-size-data-esp32,
+          # report-size-data-esp32s3, etc. The action searches recent
+          # workflow runs for artifacts matching this pattern and posts a
+          # comment on any open PR it can diff a base vs. head report for;
+          # runs with nothing to compare (pushes, the monthly schedule
+          # build) are skipped automatically.
+          sketches-reports-source: report-size-data-.*

--- a/.github/workflows/report-size-trend.yml
+++ b/.github/workflows/report-size-trend.yml
@@ -61,7 +61,11 @@ jobs:
       - name: Download this run's size report
         uses: actions/download-artifact@v8
         with:
-          name: report-size-data
+          # The "Compile Sketches" build matrix uploads one artifact per
+          # board (report-size-data-esp32, report-size-data-esp32s3, ...);
+          # merge them all into a single directory for the script below.
+          pattern: report-size-data-*
+          merge-multiple: true
           run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: report-size-data

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 
 Bluetooth LE Gamepad library for the ESP32
 
+## Supported boards
+This library depends only on [NimBLE-Arduino](https://github.com/h2zero/NimBLE-Arduino) and has no chip-specific code, so it should work on any Espressif MCU with a BLE radio. The following are currently built and compile-tested in CI (see [main.yml](.github/workflows/main.yml)):
+
+ - ESP32
+ - ESP32-S3
+ - ESP32-C3
+ - ESP32-C6
+
+Other BLE-capable variants (e.g. ESP32-C2, ESP32-H2) are likely to work too, but aren't currently covered by CI. Note that plain ESP32-S2 has no Bluetooth radio at all, so it can't run this library.
+
 ## License
 Published under the MIT license. Please see license.txt.
 

--- a/test/ci_build/platformio.ini
+++ b/test/ci_build/platformio.ini
@@ -30,3 +30,14 @@ lib_deps =
   ../../
 build_flags =
   -D BLE_GAMEPAD_DEBUG=1
+
+[env:esp32c6]
+platform = espressif32
+board = esp32-c6-devkitc-1
+framework = arduino
+lib_ldf_mode = deep+
+lib_deps =
+  h2zero/NimBLE-Arduino
+  ../../
+build_flags =
+  -D BLE_GAMEPAD_DEBUG=1

--- a/test/ci_build/platformio.ini
+++ b/test/ci_build/platformio.ini
@@ -32,7 +32,11 @@ build_flags =
   -D BLE_GAMEPAD_DEBUG=1
 
 [env:esp32c6]
-platform = espressif32
+# The official "espressif32" platform's esp32-c6-devkitc-1 board only
+# declares espidf support, not arduino, so it fails with "This board
+# doesn't support arduino framework!". The pioarduino fork keeps the
+# board defs current with Arduino core releases; use it here instead.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 board = esp32-c6-devkitc-1
 framework = arduino
 lib_ldf_mode = deep+

--- a/test/ci_build/platformio.ini
+++ b/test/ci_build/platformio.ini
@@ -9,9 +9,9 @@ lib_deps =
 build_flags =
   -D BLE_GAMEPAD_DEBUG=1
 
-[env:lolin_c3_mini]
+[env:esp32c3]
 platform = espressif32
-board = lolin_c3_mini
+board = esp32-c3-devkitc-02
 framework = arduino
 lib_ldf_mode = deep+
 lib_deps =

--- a/test/ci_build/platformio.ini
+++ b/test/ci_build/platformio.ini
@@ -31,17 +31,21 @@ lib_deps =
 build_flags =
   -D BLE_GAMEPAD_DEBUG=1
 
-[env:esp32c6]
-# The official "espressif32" platform's esp32-c6-devkitc-1 board only
-# declares espidf support, not arduino, so it fails with "This board
-# doesn't support arduino framework!". The pioarduino fork keeps the
-# board defs current with Arduino core releases; use it here instead.
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
-board = esp32-c6-devkitc-1
-framework = arduino
-lib_ldf_mode = deep+
-lib_deps =
-  h2zero/NimBLE-Arduino
-  ../../
-build_flags =
-  -D BLE_GAMEPAD_DEBUG=1
+# [env:esp32c6]
+# Disabled for now: the official "espressif32" platform's
+# esp32-c6-devkitc-1 board only declares espidf support, not arduino,
+# so this fails with "This board doesn't support arduino framework!".
+# It does work against the actively-maintained pioarduino fork
+# (platform = https://github.com/pioarduino/platform-espressif32/releases/download/<version>/platform-espressif32.zip),
+# but we're holding off on that until the official platform reaches
+# GA support for C6 under Arduino. Re-enable in .github/workflows/platformio.yml
+# once that lands.
+# platform = espressif32
+# board = esp32-c6-devkitc-1
+# framework = arduino
+# lib_ldf_mode = deep+
+# lib_deps =
+#   h2zero/NimBLE-Arduino
+#   ../../
+# build_flags =
+#   -D BLE_GAMEPAD_DEBUG=1


### PR DESCRIPTION
Compile Sketches now runs the example matrix against esp32, esp32s3, esp32c3 and esp32c6 instead of just the original esp32, and discovers sketch paths dynamically from examples/ instead of a hard-coded list.

Each matrix leg also renders its flash/RAM report as a Markdown table into the job's step summary, so memory usage (and the delta versus the previous commit) is visible directly on the workflow run page instead of only in the weekly PR delta comment.

report-size-deltas.yml and report-size-trend.yml are updated to match the now per-board artifact names, and README.md documents the boards currently covered by CI.