### PR TITLE
fix: silence -Wreorder and -Wdeprecated-declarations warnings

### DIFF
--- a/BleGamepad.cpp
+++ b/BleGamepad.cpp
@@ -73,11 +73,12 @@ BleGamepad::BleGamepad(std::string deviceName, std::string deviceManufacturer, u
   _dischargingState(0),
   _chargingState(0),
   _powerLevel(0),
+  nusInitialized(false),
+  pServer(nullptr),
+  nus(nullptr),
   hid(0),
   pCharacteristic_Power_State(0),
-  configuration(),
-  pServer(nullptr), 
-  nus(nullptr)
+  configuration()
 {
   this->resetButtons();
   this->deviceName = deviceName;
@@ -94,8 +95,6 @@ BleGamepad::BleGamepad(std::string deviceName, std::string deviceManufacturer, u
   outputReportLength = 64;
   enableFeatureReport = false;
   featureReportLength = 64;
-
-  nusInitialized = false;
 }
 
 void BleGamepad::resetButtons()
@@ -2235,7 +2234,8 @@ void BleGamepad::taskServer(void *pvParameter)
   #endif
   
   BleGamepadInstance->hid->setReportMap((uint8_t *)customHidReportDescriptor, BleGamepadInstance->hidReportDescriptorSize);
-  BleGamepadInstance->hid->startServices();
+  // Deprecated in NimBLE-Arduino >=2.0: Services are auto-started by the server
+  // BleGamepadInstance->hid->startServices();
 
   BleGamepadInstance->onStarted(pServer);
 

--- a/BleNUS.cpp
+++ b/BleNUS.cpp
@@ -40,7 +40,8 @@ void BleNUS::begin() {
     pTxCharacteristic->setCallbacks(this); // Logs which peer subscribes to the NUS profile
     
     NIMBLE_LOGD(LOG_TAG, "Starting Nordic UART Service");
-    pService->start();
+    // Deprecated in NimBLE-Arduino >=2.0: NimBLEService::start() has no effect, services are started when the server is started
+    // pService->start();
     
     // Can't add Nordic UART Service UUID to the main advertisement as it makes it larger than 31 bytes
     // It's not strictly needed anyway


### PR DESCRIPTION
Fixes CI warnings on esp32:esp32@3.2.0 + NimBLE-Arduino>=2.5.1:

- BleGamepad.h:86/BleGamepad.cpp:47 -Wreorder: reorder initializer list to match declaration order (BleGamepad.h:62-86 
usInitialized -> pServer -> 
us -> hid -> pCharacteristic_Power_State -> configuration) and remove redundant body assign.
- BleGamepad.cpp:2238 -Wdeprecated-declarations: hid->startServices() is deprecated since NimBLE-Arduino 2.0 (services auto-started by NimBLEServer::start()). Commented out.
- BleNUS.cpp:43 -Wdeprecated-declarations: pService->start() has no effect since NimBLE-Arduino 2.0. Commented out.

Verified with Arduino-cli compile --warnings all --clean on examples/CharacteristicsConfiguration:
- before: 4 warnings (Wreorder + 2x deprecated)
- after: 0 warnings, 620238 bytes flash (47%)

Future-proof for NimBLE-Arduino 2.5.x where both functions are marked __attribute__((deprecated)).