### PR TITLE
hil: scripts/hil.sh runs through tester/test-all.sh (rig lock + retry)

### DIFF
--- a/HilTesting.md
+++ b/HilTesting.md
@@ -40,6 +40,7 @@ git clone https://github.com/LeeNX/ESP32-BLE-Gamepad-HIL ~/src/ESP32-BLE-Gamepad
 # from this repo, on whatever branch/working tree you want tested:
 HIL_SSH_HOST=<tester> HIL_SSH_USER=<user> scripts/hil.sh          # functional suite
 HIL_SSH_HOST=<tester> HIL_SSH_USER=<user> scripts/hil.sh --bench  # + latency benchmark
+scripts/hil.sh --by-board                                         # boards as parallel lanes (functional, ~3x)
 scripts/hil.sh --boards esp32dev --profiles "default maxbtn"
 scripts/hil.sh --profiles default -- -k buttons                   # args after -- go to pytest
 ```
@@ -51,8 +52,11 @@ scripts/hil.sh --profiles default -- -k buttons                   # args after -
 2. builds the `hil_runner` firmware bundles here;
 3. rsyncs the harness code **and** the bundles to the tester (its real
    serial-port config is preserved);
-4. ssh-runs `tester/test.sh` for each bundle — esptool flash, re-pair on any HID
-   descriptor change, pytest, and (with `--bench`) the benchmark sweep;
+4. ssh-runs `tester/test-all.sh` — which takes the **rig lock** (one physical
+   rig; blocks until any CI or other local run releases it), then for each
+   bundle: esptool flash, re-pair on any HID descriptor change, pytest, the
+   `--bench` sweep, one retry on failure. `--by-board` runs the boards as
+   parallel lanes (functional only — the latency sweep stays sequential);
 5. pulls `results/` back into `./hil-results/` (gitignored) and regenerates the
    distilled table + SVG charts.
 
@@ -67,7 +71,10 @@ from GitHub-hosted runners: it builds the firmware bundles, joins the tailnet as
 an ephemeral node (`tailscale/github-action`), and ssh-es to the tester by its
 MagicDNS name — no self-hosted runner, no inbound ports. It accepts a
 `repository_dispatch` of type `hil` with `client_payload.lib_repo` /
-`lib_ref`, so this library repo can hand it a ref to test.
+`lib_ref`, so this library repo can hand it a ref to test. A manual
+`workflow_dispatch` on the rig also takes `boards` / `profiles` / `test_filter`
+(a pytest `-k` expression) to narrow a run — handy for chasing one red test
+without the full ~80-minute sweep.
 
 This repo's `.github/workflows/hil.yml` is that trigger. It runs on push to
 `master`, on PRs that touch the HID/report/GATT source (path-filtered), weekly,

--- a/scripts/hil.sh
+++ b/scripts/hil.sh
@@ -11,8 +11,13 @@
 #
 #   scripts/hil.sh                                   # all boards + profiles, no bench
 #   scripts/hil.sh --bench                           # + latency/throughput benchmark
+#   scripts/hil.sh --by-board                        # boards as parallel lanes (functional only, ~3x)
 #   scripts/hil.sh --boards esp32dev --profiles "default maxbtn"
 #   scripts/hil.sh --profiles default -- -k buttons  # args after -- go to pytest
+#
+# On the tester it runs through tester/test-all.sh, which takes the rig lock
+# (waits out any CI or other local run) and retries a bundle once. --by-board
+# and --bench are mutually exclusive (the latency sweep must stay sequential).
 #
 # Env (HIL_SSH_HOST / HIL_SSH_USER are required -- set them or your ssh config):
 #   HIL_REPO      local ESP32-BLE-Gamepad-HIL checkout  (default: ~/src/ESP32-BLE-Gamepad-HIL)
@@ -34,16 +39,15 @@ REMOTE_DIR=ESP32-BLE-Gamepad-HIL          # harness checkout on the tester (see 
 SSH=(ssh -o BatchMode=yes); RSYNC_E=(ssh -o BatchMode=yes)
 if [[ -n ${HIL_SSH_KEY:-} ]]; then SSH+=(-i "$HIL_SSH_KEY"); RSYNC_E+=(-i "$HIL_SSH_KEY"); fi
 
-BOARDS=${HIL_BOARDS:-"esp32dev esp32c3"}
+BOARDS=${HIL_BOARDS:-"esp32dev esp32c3 esp32s3"}
 PROFILES=${HIL_PROFILES:-"default signed-axes specials minimal maxbtn reports"}
-BENCH=()
-PYTEST_ARGS=()
+TESTALL_ARGS=()   # passed to tester/test-all.sh (--bench / --by-board / pytest args)
 seen_ddash=0
 while [[ $# -gt 0 ]]; do
-  if [[ $seen_ddash == 1 ]]; then PYTEST_ARGS+=("$1"); shift; continue; fi
+  if [[ $seen_ddash == 1 ]]; then TESTALL_ARGS+=("$1"); shift; continue; fi
   case "$1" in
     --) seen_ddash=1; shift ;;
-    --bench) BENCH=(--bench); shift ;;
+    --bench | --by-board) TESTALL_ARGS+=("$1"); shift ;;
     --boards) BOARDS=$2; shift 2 ;;
     --profiles) PROFILES=$2; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
@@ -94,25 +98,19 @@ rsync -a --delete -e "${RSYNC_E[*]}" \
 rsync -a --delete -e "${RSYNC_E[*]}" "$HIL_REPO"/bundles/ "$PI:hil-bundles/"
 
 # --- 4. flash + test each bundle on the Pi ------------------------------
-# extra args are appended straight to pytest (our --bench flag + anything the
-# caller put after --, e.g. -k buttons). Per-bundle output streams live; each
-# bundle prints its own phase banners + one-line verdict (tester/test.sh).
+# tester/test-all.sh loops ~/hil-bundles, retries a bundle once, and takes the
+# rig lock (blocks until any CI / other local run releases it). Extra args
+# (--bench / --by-board / anything after --) pass straight through.
 rc=0
-"${SSH[@]}" "$PI" "bash -s --" "$REMOTE_DIR" "${BENCH[@]}" "${PYTEST_ARGS[@]}" <<'REMOTE' || rc=$?
+"${SSH[@]}" "$PI" "bash -s --" "$REMOTE_DIR" "${TESTALL_ARGS[@]}" <<'REMOTE' || rc=$?
 set -e
 REMOTE_DIR="$1"; shift
 cd ~/"$REMOTE_DIR"
 rm -rf results && mkdir results
-total=$(ls -d ~/hil-bundles/*/ | wc -l)
-echo "== $total bundle(s) to flash + test on $(hostname)"
-rc=0; i=0
-for b in ~/hil-bundles/*/; do
-  i=$((i+1))
-  echo; echo "########## [$i/$total] $(basename "$b")  $(date +%H:%M:%S)"
-  ./tester/test.sh "$b" "$@" || rc=$?
-done
+trc=0
+./tester/test-all.sh "$@" || trc=$?
 echo; echo '########## verdicts'; cat results/run-verdicts.md 2>/dev/null || true
-exit $rc
+exit $trc
 REMOTE
 
 # --- 5. pull results + regenerate the distilled table/charts -----------


### PR DESCRIPTION
The HIL rig (v0.1.2+) added an flock so local runs and CI can't stomp each other, and a one-retry-per-bundle wrapper. scripts/hil.sh was still rolling its own bundle loop -- no lock (could collide with a CI run mid-flash), no retry (a single C3/S3 UART byte-drop failed the whole run). Delegate to tester/test-all.sh instead.

- --by-board passthrough: boards as parallel lanes, functional only, ~3x on a 3-board rig (rig v0.2.0). Mutually exclusive with --bench.
- default boards now include esp32s3 (detect.py skips any that aren't wired).
- HilTesting.md: the rig lock, --by-board, and the rig's focused workflow_dispatch inputs (boards / profiles / test_filter).

Rig repo: LeeNX/ESP32-BLE-Gamepad-HIL v0.2.0.