### PR TITLE
Feature Report: seed the capability bitmask once, not on every read

### DIFF
--- a/BleFeatureReport.cpp
+++ b/BleFeatureReport.cpp
@@ -6,6 +6,7 @@ BleFeatureReceiver::BleFeatureReceiver(uint16_t featureReportLength, BleGamepadC
     this->configuration = configuration;
     featureBuffer = new uint8_t[featureReportLength];
     memset(featureBuffer, 0, featureReportLength);
+    buildFeatureReport(); // seed the buffer with the capability defaults, once
 }
 
 BleFeatureReceiver::~BleFeatureReceiver()
@@ -17,7 +18,11 @@ BleFeatureReceiver::~BleFeatureReceiver()
     }
 }
 
-// Builds a capability report modeled on the SInput "Features 0x02" report:
+// Seeds featureBuffer[0..3] with a capability report modeled on the SInput
+// "Features 0x02" layout. Called once at construction so a host that reads the
+// Feature Report without anything having written it still sees sane defaults.
+// It is NOT re-run on every read -- that would clobber whatever the sketch put
+// there with setFeatureBuffer() (the bidirectional buffer in GattVsHid.md B).
 // https://docs.handheldlegend.com/s/sinput/doc/features-response-bytes-1lMp7WL7bq
 void BleFeatureReceiver::buildFeatureReport()
 {
@@ -40,9 +45,8 @@ void BleFeatureReceiver::buildFeatureReport()
 
 void BleFeatureReceiver::onRead(NimBLECharacteristic *pCharacteristic, NimBLEConnInfo& connInfo)
 {
-    buildFeatureReport();
-
-    // Set data for the host
+    // Serve whatever is in the buffer -- the capability defaults from the
+    // constructor, or whatever setFeatureBuffer() / a host onWrite last stored.
     pCharacteristic->setValue(featureBuffer, featureReportLength);
 }
 

--- a/GattVsHid.md
+++ b/GattVsHid.md
@@ -166,13 +166,15 @@ If you're not targeting SInput specifically, the library's older, more
 generic mechanism still exists independently of SInput mode: add bytes to
 the configurable Output Report (host → device) and/or Feature Report
 (bidirectional) via `setEnableOutputReport()`/`setEnableFeatureReport()`.
-`BleFeatureReceiver::buildFeatureReport()` in
-[BleFeatureReport.cpp](BleFeatureReport.cpp) already does this for a
-capability bitmask happening to reuse SInput's bit layout — but to be clear,
-**this is a different, non-SInput mechanism**: it rides on the GATT Feature
-Report characteristic, which SDL's SInput driver never reads (see the note
-above). It's still useful for a custom app that talks `hidraw`/`hidapi`
-directly against its own protocol, just not for SDL's SInput recognition.
+The Feature Report buffer starts seeded with a small capability bitmask
+(`BleFeatureReceiver::buildFeatureReport()` in
+[BleFeatureReport.cpp](BleFeatureReport.cpp), a layout that happens to reuse
+SInput's bits); firmware overwrites it with `setFeatureBuffer()` and the host
+reads back exactly what was stored. To be clear, **this is a different,
+non-SInput mechanism**: it rides on the GATT Feature Report characteristic,
+which SDL's SInput driver never reads (see the note above). It's still useful
+for a custom app that talks `hidraw`/`hidapi` directly against its own
+protocol, just not for SDL's SInput recognition.
 
 - Reachable from: any app already reading this device's Input Report via
   `hidraw`/`hidapi` — i.e. exactly the kind of code a game or a custom


### PR DESCRIPTION
Found with HIL service and seen today again - 

https://github.com/lemmingDev/ESP32-BLE-Gamepad/actions/runs/34827033460 -> https://github.com/LeeNX/ESP32-BLE-Gamepad-HIL/actions/runs/34827045795
